### PR TITLE
Input file check via magic

### DIFF
--- a/.github/workflows/build_and_publish.yml
+++ b/.github/workflows/build_and_publish.yml
@@ -47,12 +47,12 @@ jobs:
       if: startsWith(matrix.os, 'ubuntu')
       run: |
         sudo apt-get update
-        sudo apt-get install autoconf automake libtool pkg-config gettext libjson-c-dev libpcap-dev
+        sudo apt-get install autoconf automake libtool pkg-config gettext libjson-c-dev libpcap-dev libmagic1
         sudo apt-get install libusb-1.0-0-dev libdbus-glib-1-dev libbluetooth-dev libnl-genl-3-dev flex bison
     - name: Installing macOS prerequisites
       if: startsWith(matrix.os, 'macOS')
       run: |
-        brew install autoconf automake libtool pkg-config gettext json-c
+        brew install autoconf automake libtool pkg-config gettext json-c libmagic
     - name: Installing NFStream requirements
       if: steps.pip-cache.outputs.cache-hit != 'true'
       run: |

--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -9,3 +9,4 @@ wheel>=0.37.0
 twine>=3.4.2
 setuptools>=57.4.0
 codecov>=2.1.12
+python-magic>=0.4.24

--- a/nfstream/streamer.py
+++ b/nfstream/streamer.py
@@ -19,6 +19,7 @@ import pandas as pd
 import time as tm
 import os
 import platform
+import magic
 from collections.abc import Iterable
 from psutil import net_if_addrs, cpu_count
 from os.path import isfile
@@ -98,7 +99,7 @@ class NFStreamer(object):
         available_interfaces = net_if_addrs().keys()
         if value in available_interfaces:
             self._mode = 1
-        elif (".pcap" in value[-5:] or ".pcapng" in value[-7:]) and isfile(value):
+        elif isfile(value) and "pcap" in magic.from_file(value):
             self._mode = 0
         else:
             raise ValueError("Please specify a pcap file path or a valid network interface name as source.")

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ numpy<=1.18.5; sys_platform == 'darwin'
 pandas>=1.1.5; platform.python_implementation == 'CPython'
 pandas<=1.2.5; platform.python_implementation == 'PyPy'
 dpkt>=1.9.7
+python-magic>=0.4.24

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,6 @@ import sys
 import os
 import subprocess
 import platform
-import magic
 
 if (not sys.version_info[0] == 3) and (not sys.version_info[1] >= 6):
     sys.exit("Sorry, nfstream requires Python3.6+ versions.")
@@ -68,7 +67,8 @@ needs_pytest = {'pytest', 'test', 'ptr'}.intersection(sys.argv)
 pytest_runner = ['pytest-runner'] if needs_pytest else []
 install_requires = ['cffi>=1.14.6',
                     'psutil>=5.8.0',
-                    'dpkt>=1.9.7']
+                    'dpkt>=1.9.7',
+		    'python-magic>=0.4.24']
 
 # This is mandatory to fix both issues with numpy using Accelerate backend on macos and pandas issues with PyPy
 if sys.platform == 'darwin':

--- a/setup.py
+++ b/setup.py
@@ -17,6 +17,7 @@ import sys
 import os
 import subprocess
 import platform
+import magic
 
 if (not sys.version_info[0] == 3) and (not sys.version_info[1] >= 6):
     sys.exit("Sorry, nfstream requires Python3.6+ versions.")


### PR DESCRIPTION
# Pull Request Template

## Description

The check of the input file (i.e. pcap and nic) was implemented in a way such that it considers proper file naming. However, a pcap(ng) file can also be stored with different name extensions. A proper way of checking the input file type is via magic number. 

This PR does not fix any known issue. It aims to improve NFStream.

## Type of change

This commit is a minor improvement.

## How Has This Been Tested?

The tests were run on my local computer (a Macbook Air). All the existing unit tests passed with the changes implemented.

**Test Configuration**:
* OS version: MacOS 12.0.1
* Python version: Python 3.9
* Hardware: Apple

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings