### PR TITLE
[CI] Add CIFuzz action

### DIFF
--- a/.github/workflows/cifuzz.yml
+++ b/.github/workflows/cifuzz.yml
@@ -1,0 +1,26 @@
+name: CIFuzz
+on: [pull_request]
+jobs:
+  Fuzzing:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Build Fuzzers
+      id: build
+      uses: google/oss-fuzz/infra/cifuzz/actions/build_fuzzers@master
+      with:
+        oss-fuzz-project-name: 'nfstream'
+        dry-run: false
+        language: python
+    - name: Run Fuzzers
+      uses: google/oss-fuzz/infra/cifuzz/actions/run_fuzzers@master
+      with:
+        oss-fuzz-project-name: 'nfstream'
+        fuzz-seconds: 300
+        dry-run: false
+        language: python
+    - name: Upload Crash
+      uses: actions/upload-artifact@v3
+      if: failure() && steps.build.outcome == 'success'
+      with:
+        name: artifacts
+        path: ./out/artifacts


### PR DESCRIPTION
Signed-off-by: David Korczynski <david@adalogics.com>

## Description

Please include a summary of the change and which issue is fixed. 
Please also include relevant motivation and context. List any dependencies that are required for this change.

Add [CIFuzz](https://google.github.io/oss-fuzz/getting-started/continuous-integration/) workflow action to have fuzzers build and run on each PR. This is a service offered by OSS-Fuzz where nfstream was recently integrated into. CIFuzz can help detect catch regressions and fuzzing build issues early, and has a variety of features (see the URL above). In the current PR the fuzzers gets build on a pull request and will run for 300 seconds.

Fixes # (issue)

## Type of change
New feature in the CI

## How Has This Been Tested?

The fuzzers will be automatically run in the CI.

## Checklist:

Given this is the CI there were many checklist points that are not relevant.
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] I have checked my code and corrected any misspellings