### PR TITLE
Add flow risks

### DIFF
--- a/nfstream/engine/lib_engine.c
+++ b/nfstream/engine/lib_engine.c
@@ -75,8 +75,8 @@ typedef struct nf_stat {
 } nf_stat_t;
 
 typedef struct risk {
-  char risk[256];
-  char risk_severity[256];
+  char risk[40];
+  char risk_severity[10];
   uint16_t risk_score_total;
   uint16_t risk_score_client;
   uint16_t risk_score_server;
@@ -903,9 +903,13 @@ static void flow_bidirectional_dissection_collect_info(struct ndpi_detection_mod
         
         uint16_t client_score, server_score;
         uint16_t score = ndpi_risk2score(r, &client_score, &server_score);
+        
+        char* risk = ndpi_risk2str(risk_info->risk);
+        memcpy(flow->nf_risk_t[j].risk, risk, strlen(risk));
 
-        memcpy(flow->nf_risk_t[j].risk, ndpi_risk2str(risk_info->risk), sizeof(flow->nf_risk_t[j].risk));
-        memcpy(flow->nf_risk_t[j].risk_severity, ndpi_severity2str(risk_info->severity), sizeof(flow->nf_risk_t[j].risk_severity));
+        char* severity = ndpi_severity2str(risk_info->severity);
+        memcpy(flow->nf_risk_t[j].risk_severity, severity, strlen(severity));
+
         flow->nf_risk_t[j].risk_score_total = score;
         flow->nf_risk_t[j].risk_score_client = client_score;
         flow->nf_risk_t[j].risk_score_server = server_score;

--- a/nfstream/flow.py
+++ b/nfstream/flow.py
@@ -16,7 +16,6 @@ If not, see <http://www.gnu.org/licenses/>.
 from collections import namedtuple
 from math import sqrt
 from .utils import NFEvent
-from inspect import getmembers
 
 
 # When NFStream is extended with plugins, packer C structure is pythonized using the following namedtuple.

--- a/nfstream/flow.py
+++ b/nfstream/flow.py
@@ -206,6 +206,11 @@ class NFlow(object):
         "server_fingerprint",
         "user_agent",
         "content_type",
+        "risk",
+        "risk_severity",
+        "risk_score_total",
+        "risk_score_client",
+        "risk_score_server",
         "_C",
         "udps",
         "system_process_pid",
@@ -326,6 +331,11 @@ class NFlow(object):
                 ).decode("utf-8", errors="ignore")
                 self.application_is_guessed = self._C.guessed
                 self.application_confidence = self._C.confidence
+                self.risk = ffi.string(self._C.risk).decode("utf-8", errors="ignore")
+                self.risk_severity = ffi.string(self._C.risk_severity).decode("utf-8", errors="ignore")
+                self.risk_score_total = self._C.risk_score_total
+                self.risk_score_client = self._C.risk_score_client
+                self.risk_score_server = self._C.risk_score_server
                 self.requested_server_name = ffi.string(
                     self._C.requested_server_name
                 ).decode("utf-8", errors="ignore")
@@ -346,6 +356,11 @@ class NFlow(object):
                 self.application_category_name = None
                 self.application_is_guessed = None
                 self.application_confidence = None
+                self.risk = None
+                self.risk_severity = None
+                self.risk_score_total = None
+                self.risk_score_client = None
+                self.risk_score_server = None
                 self.requested_server_name = None
                 self.client_fingerprint = None
                 self.server_fingerprint = None
@@ -542,6 +557,12 @@ class NFlow(object):
                 )
                 self.application_is_guessed = self._C.guessed
                 self.application_confidence = self._C.confidence
+                self.risk = ffi.string(self._C.risk).decode("utf-8", errors="ignore")
+                self.risk_severity = ffi.string(self._C.risk_severity).decode("utf-8", errors="ignore")
+                self.risk_score_total = self._C.risk_score_total
+                self.risk_score_client = self._C.risk_score_client
+                self.risk_score_server = self._C.risk_score_server
+
         if splt:
             if (
                 sync_mode

--- a/nfstream/flow.py
+++ b/nfstream/flow.py
@@ -107,35 +107,35 @@ def pythonize_packet(packet, ffi, flow):
 
 def convert_struct_field(s, fields, ffi):
     for field, fieldtype in fields:
-        if fieldtype.type.kind == 'primitive':
+        if fieldtype.type.kind == "primitive":
             yield (field, getattr(s, field))
         else:
             yield (field, convert_to_python(getattr(s, field), ffi))
 
 def convert_to_python(s, ffi):
     type = ffi.typeof(s)
-    if type.kind == 'struct':
+    if type.kind == "struct":
         return dict(convert_struct_field(s, type.fields, ffi))
-    elif type.kind == 'array':
-        if type.item.kind == 'primitive':
-            if type.item.cname == 'char':
-                return ffi.string(s).decode('utf-8', errors='ignore')
+    elif type.kind == "array":
+        if type.item.kind == "primitive":
+            if type.item.cname == "char":
+                return ffi.string(s).decode("utf-8", errors="ignore")
             else:
                 return [s[i] for i in range(type.length)]
         else:
             return [ convert_to_python(s[i], ffi) for i in range(type.length) ]
-    elif type.kind == 'primitive':
+    elif type.kind == "primitive":
         return int(s)
 
 def convert_risks(s, ffi):
     risks = {}
     type = ffi.typeof(s)
-    if type.kind == 'array':
+    if type.kind == "array":
         for i in range(type.length):
             risk = convert_to_python(s[i], ffi)
-            risk_type = risk['risk']
-            if risk_type != '':
-                del risk['risk'] 
+            risk_type = risk["risk"]
+            if risk_type != "":
+                del risk["risk"] 
                 risks[risk_type] = risk
     return risks
 
@@ -150,101 +150,6 @@ class NFlow(object):
     we pay the cost of flexibility with attributes access/update.
 
     """
-    __slots__ = ('id',
-                 'expiration_id',
-                 'src_ip',
-                 'src_mac',
-                 'src_oui',
-                 'src_port',
-                 'dst_ip',
-                 'dst_mac',
-                 'dst_oui',
-                 'dst_port',
-                 'protocol',
-                 'ip_version',
-                 'vlan_id',
-                 'tunnel_id',
-                 'bidirectional_first_seen_ms',
-                 'bidirectional_last_seen_ms',
-                 'bidirectional_duration_ms',
-                 'bidirectional_packets',
-                 'bidirectional_bytes',
-                 'src2dst_first_seen_ms',
-                 'src2dst_last_seen_ms',
-                 'src2dst_duration_ms',
-                 'src2dst_packets',
-                 'src2dst_bytes',
-                 'dst2src_first_seen_ms',
-                 'dst2src_last_seen_ms',
-                 'dst2src_duration_ms',
-                 'dst2src_packets',
-                 'dst2src_bytes',
-                 'bidirectional_min_ps',
-                 'bidirectional_mean_ps',
-                 'bidirectional_stddev_ps',
-                 'bidirectional_max_ps',
-                 'src2dst_min_ps',
-                 'src2dst_mean_ps',
-                 'src2dst_stddev_ps',
-                 'src2dst_max_ps',
-                 'dst2src_min_ps',
-                 'dst2src_mean_ps',
-                 'dst2src_stddev_ps',
-                 'dst2src_max_ps',
-                 'bidirectional_min_piat_ms',
-                 'bidirectional_mean_piat_ms',
-                 'bidirectional_stddev_piat_ms',
-                 'bidirectional_max_piat_ms',
-                 'src2dst_min_piat_ms',
-                 'src2dst_mean_piat_ms',
-                 'src2dst_stddev_piat_ms',
-                 'src2dst_max_piat_ms',
-                 'dst2src_min_piat_ms',
-                 'dst2src_mean_piat_ms',
-                 'dst2src_stddev_piat_ms',
-                 'dst2src_max_piat_ms',
-                 'bidirectional_syn_packets',
-                 'bidirectional_cwr_packets',
-                 'bidirectional_ece_packets',
-                 'bidirectional_urg_packets',
-                 'bidirectional_ack_packets',
-                 'bidirectional_psh_packets',
-                 'bidirectional_rst_packets',
-                 'bidirectional_fin_packets',
-                 'src2dst_syn_packets',
-                 'src2dst_cwr_packets',
-                 'src2dst_ece_packets',
-                 'src2dst_urg_packets',
-                 'src2dst_ack_packets',
-                 'src2dst_psh_packets',
-                 'src2dst_rst_packets',
-                 'src2dst_fin_packets',
-                 'dst2src_syn_packets',
-                 'dst2src_cwr_packets',
-                 'dst2src_ece_packets',
-                 'dst2src_urg_packets',
-                 'dst2src_ack_packets',
-                 'dst2src_psh_packets',
-                 'dst2src_rst_packets',
-                 'dst2src_fin_packets',
-                 'splt_direction',
-                 'splt_ps',
-                 'splt_piat_ms',
-                 'application_name',
-                 'application_category_name',
-                 'application_is_guessed',
-                 'application_confidence',
-                 'requested_server_name',
-                 'client_fingerprint',
-                 'server_fingerprint',
-                 'user_agent',
-                 'content_type',
-                 'flow_risk',
-                 '_C',
-                 'udps',
-                 'system_process_pid',
-                 'system_process_name',
-                 'system_browser_tab')
 
     __slots__ = (
         "id",
@@ -336,11 +241,7 @@ class NFlow(object):
         "server_fingerprint",
         "user_agent",
         "content_type",
-        "risk",
-        "risk_severity",
-        "risk_score_total",
-        "risk_score_client",
-        "risk_score_server",
+        "flow_risks",
         "_C",
         "udps",
         "system_process_pid",
@@ -461,12 +362,22 @@ class NFlow(object):
                 ).decode("utf-8", errors="ignore")
                 self.application_is_guessed = self._C.guessed
                 self.application_confidence = self._C.confidence
+                self.requested_server_name = ffi.string(
+                    self._C.requested_server_name
+                ).decode("utf-8", errors="ignore")
+                self.client_fingerprint = ffi.string(self._C.c_hash).decode(
+                    "utf-8", errors="ignore"
+                )
+                self.server_fingerprint = ffi.string(self._C.s_hash).decode(
+                    "utf-8", errors="ignore"
+                )
+                self.user_agent = ffi.string(self._C.user_agent).decode(
+                    "utf-8", errors="ignore"
+                )
+                self.content_type = ffi.string(self._C.content_type).decode(
+                    "utf-8", errors="ignore"
+                )
                 self.flow_risk = convert_risks(self._C.nf_risk_t, ffi)
-                self.requested_server_name = ffi.string(self._C.requested_server_name).decode('utf-8', errors='ignore')
-                self.client_fingerprint = ffi.string(self._C.c_hash).decode('utf-8', errors='ignore')
-                self.server_fingerprint = ffi.string(self._C.s_hash).decode('utf-8', errors='ignore')
-                self.user_agent = ffi.string(self._C.user_agent).decode('utf-8', errors='ignore')
-                self.content_type = ffi.string(self._C.content_type).decode('utf-8', errors='ignore')
             else:
                 self.application_name = None
                 self.application_category_name = None
@@ -670,8 +581,6 @@ class NFlow(object):
                 self.application_is_guessed = self._C.guessed
                 self.application_confidence = self._C.confidence
                 self.flow_risk = convert_risks(self._C.nf_risk_t, ffi)
-                
-
         if splt:
             if (
                 sync_mode

--- a/nfstream/flow.py
+++ b/nfstream/flow.py
@@ -461,7 +461,7 @@ class NFlow(object):
                 ).decode("utf-8", errors="ignore")
                 self.application_is_guessed = self._C.guessed
                 self.application_confidence = self._C.confidence
-                convert_risks(self._C.nf_risk_t, ffi)
+                self.flow_risk = convert_risks(self._C.nf_risk_t, ffi)
                 self.requested_server_name = ffi.string(self._C.requested_server_name).decode('utf-8', errors='ignore')
                 self.client_fingerprint = ffi.string(self._C.c_hash).decode('utf-8', errors='ignore')
                 self.server_fingerprint = ffi.string(self._C.s_hash).decode('utf-8', errors='ignore')

--- a/nfstream/flow.py
+++ b/nfstream/flow.py
@@ -241,7 +241,7 @@ class NFlow(object):
         "server_fingerprint",
         "user_agent",
         "content_type",
-        "flow_risks",
+        "flow_risk",
         "_C",
         "udps",
         "system_process_pid",

--- a/tests.py
+++ b/tests.py
@@ -880,6 +880,27 @@ class NFStreamTest(object):
             "{}\t: {}".format(".test_max_nflows".ljust(60, " "), colored("OK", "green"))
         )
 
+    @staticmethod
+    def test_flow_risk():
+        print(
+            "\n----------------------------------------------------------------------"
+        )
+        for flow in NFStreamer(source=os.path.join("tests", "pcaps", "tls_alert.pcap")):
+            assert flow.flow_risk != {}
+            assert flow.flow_risk["Obsolete TLS (v1.1 or older)"]["risk_severity"] == "High"
+            assert flow.flow_risk["Obsolete TLS (v1.1 or older)"]["risk_score_total"] == 310
+            assert flow.flow_risk["Obsolete TLS (v1.1 or older)"]["risk_score_client"] == 275
+            assert flow.flow_risk["Obsolete TLS (v1.1 or older)"]["risk_score_server"] == 35
+
+            assert flow.flow_risk["TLS Fatal Alert"]["risk_severity"] == "Low"
+            assert flow.flow_risk["TLS Fatal Alert"]["risk_score_total"] == 200
+            assert flow.flow_risk["TLS Fatal Alert"]["risk_score_client"] == 160
+            assert flow.flow_risk["TLS Fatal Alert"]["risk_score_server"] == 40
+
+        print(
+            "{}\t: {}".format(".test_flow_risk".ljust(60, " "), colored("OK", "green"))
+        )
+
 
 if __name__ == "__main__":
     # IMPORTANT: As NFStream input is network bytes, we rely on fuzzing techniques to ensure robustness.
@@ -917,3 +938,4 @@ if __name__ == "__main__":
     NFStreamTest.test_mdns()
     NFStreamTest.test_multi_files()
     NFStreamTest.test_max_nflows()
+    NFStreamTest.test_flow_risk()


### PR DESCRIPTION
# Add nDPI flow risks

## Description

I have added the flow risks of nDPI. I adapted the `lib_engine.c` and the python wrapper, respectively.

Info:
I will update the documentation and tests if this general approach is alright.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

```python
from nfstream import NFStreamer


my_streamer = NFStreamer(source="tests/pcaps/tls-esni-fuzzed.pcap", # Live capture mode. 
                         # Disable L7 dissection for readability purpose only.
                         n_dissections=2,
                         statistical_analysis=True,
                         system_visibility_poll_ms=100,
                         system_visibility_mode=1)
                         
for flow in my_streamer:
    print(flow)  # print it.
```

Results in:

```
NFlow(id=0,
      expiration_id=0,
      src_ip=192.168.1.12,
      src_mac=28:37:37:00:6d:c8,
      src_oui=28:37:37,
      src_port=49897,
      dst_ip=104.22.71.197,
      dst_mac=10:13:31:f1:39:76,
      dst_oui=10:13:31,
      dst_port=443,
      protocol=6,
      ip_version=4,
      vlan_id=0,
      tunnel_id=0,
      bidirectional_first_seen_ms=1590680391590,
      bidirectional_last_seen_ms=1590680391590,
      bidirectional_duration_ms=0,
      bidirectional_packets=1,
      bidirectional_bytes=770,
      src2dst_first_seen_ms=1590680391590,
      src2dst_last_seen_ms=1590680391590,
      src2dst_duration_ms=0,
      src2dst_packets=1,
      src2dst_bytes=770,
      dst2src_first_seen_ms=0,
      dst2src_last_seen_ms=0,
      dst2src_duration_ms=0,
      dst2src_packets=0,
      dst2src_bytes=0,
      bidirectional_min_ps=770,
      bidirectional_mean_ps=770.0,
      bidirectional_stddev_ps=0.0,
      bidirectional_max_ps=770,
      src2dst_min_ps=770,
      src2dst_mean_ps=770.0,
      src2dst_stddev_ps=0.0,
      src2dst_max_ps=770,
      dst2src_min_ps=0,
      dst2src_mean_ps=0.0,
      dst2src_stddev_ps=0.0,
      dst2src_max_ps=0,
      bidirectional_min_piat_ms=0,
      bidirectional_mean_piat_ms=0.0,
      bidirectional_stddev_piat_ms=0.0,
      bidirectional_max_piat_ms=0,
      src2dst_min_piat_ms=0,
      src2dst_mean_piat_ms=0.0,
      src2dst_stddev_piat_ms=0.0,
      src2dst_max_piat_ms=0,
      dst2src_min_piat_ms=0,
      dst2src_mean_piat_ms=0.0,
      dst2src_stddev_piat_ms=0.0,
      dst2src_max_piat_ms=0,
      bidirectional_syn_packets=0,
      bidirectional_cwr_packets=0,
      bidirectional_ece_packets=0,
      bidirectional_urg_packets=0,
      bidirectional_ack_packets=1,
      bidirectional_psh_packets=1,
      bidirectional_rst_packets=0,
      bidirectional_fin_packets=0,
      src2dst_syn_packets=0,
      src2dst_cwr_packets=0,
      src2dst_ece_packets=0,
      src2dst_urg_packets=0,
      src2dst_ack_packets=1,
      src2dst_psh_packets=1,
      src2dst_rst_packets=0,
      src2dst_fin_packets=0,
      dst2src_syn_packets=0,
      dst2src_cwr_packets=0,
      dst2src_ece_packets=0,
      dst2src_urg_packets=0,
      dst2src_ack_packets=0,
      dst2src_psh_packets=0,
      dst2src_rst_packets=0,
      dst2src_fin_packets=0,
      application_name=TLS,
      application_category_name=Web,
      application_is_guessed=0,
      application_confidence=6,
      requested_server_name=,
      client_fingerprint=957015a0b1e2500d8777219893a09495,
      server_fingerprint=,
      user_agent=,
      content_type=,
      flow_risk={'Missing SNI TLS Extn': {'risk_severity': 'Medium', 'risk_score_total': 300, 'risk_score_client': 210, 'risk_score_server': 90}, 'Unidirectional Traffic': {'risk_severity': 'Low', 'risk_score_total': 500, 'risk_score_client': 430, 'risk_score_server': 70}})
NFlow(id=1,
      expiration_id=0,
      src_ip=192.168.1.12,
      src_mac=28:37:37:00:6d:c8,
      src_oui=28:37:37,
      src_port=49887,
      dst_ip=104.16.125.175,
      dst_mac=10:13:31:f1:39:76,
      dst_oui=10:13:31,
      dst_port=443,
      protocol=6,
      ip_version=4,
      vlan_id=0,
      tunnel_id=0,
      bidirectional_first_seen_ms=1590680387847,
      bidirectional_last_seen_ms=1590680387847,
      bidirectional_duration_ms=0,
      bidirectional_packets=1,
      bidirectional_bytes=770,
      src2dst_first_seen_ms=1590680387847,
      src2dst_last_seen_ms=1590680387847,
      src2dst_duration_ms=0,
      src2dst_packets=1,
      src2dst_bytes=770,
      dst2src_first_seen_ms=0,
      dst2src_last_seen_ms=0,
      dst2src_duration_ms=0,
      dst2src_packets=0,
      dst2src_bytes=0,
      bidirectional_min_ps=770,
      bidirectional_mean_ps=770.0,
      bidirectional_stddev_ps=0.0,
      bidirectional_max_ps=770,
      src2dst_min_ps=770,
      src2dst_mean_ps=770.0,
      src2dst_stddev_ps=0.0,
      src2dst_max_ps=770,
      dst2src_min_ps=0,
      dst2src_mean_ps=0.0,
      dst2src_stddev_ps=0.0,
      dst2src_max_ps=0,
      bidirectional_min_piat_ms=0,
      bidirectional_mean_piat_ms=0.0,
      bidirectional_stddev_piat_ms=0.0,
      bidirectional_max_piat_ms=0,
      src2dst_min_piat_ms=0,
      src2dst_mean_piat_ms=0.0,
      src2dst_stddev_piat_ms=0.0,
      src2dst_max_piat_ms=0,
      dst2src_min_piat_ms=0,
      dst2src_mean_piat_ms=0.0,
      dst2src_stddev_piat_ms=0.0,
      dst2src_max_piat_ms=0,
      bidirectional_syn_packets=0,
      bidirectional_cwr_packets=0,
      bidirectional_ece_packets=0,
      bidirectional_urg_packets=0,
      bidirectional_ack_packets=1,
      bidirectional_psh_packets=1,
      bidirectional_rst_packets=0,
      bidirectional_fin_packets=0,
      src2dst_syn_packets=0,
      src2dst_cwr_packets=0,
      src2dst_ece_packets=0,
      src2dst_urg_packets=0,
      src2dst_ack_packets=1,
      src2dst_psh_packets=1,
      src2dst_rst_packets=0,
      src2dst_fin_packets=0,
      dst2src_syn_packets=0,
      dst2src_cwr_packets=0,
      dst2src_ece_packets=0,
      dst2src_urg_packets=0,
      dst2src_ack_packets=0,
      dst2src_psh_packets=0,
      dst2src_rst_packets=0,
      dst2src_fin_packets=0,
      application_name=TLS,
      application_category_name=Web,
      application_is_guessed=0,
      application_confidence=6,
      requested_server_name=,
      client_fingerprint=957015a0b1e2500d8777219893a09495,
      server_fingerprint=,
      user_agent=,
      content_type=,
      flow_risk={'Unidirectional Traffic': {'risk_severity': 'Low', 'risk_score_total': 500, 'risk_score_client': 430, 'risk_score_server': 70}})
NFlow(id=2,
      expiration_id=0,
      src_ip=192.168.1.12,
      src_mac=28:37:37:00:6d:c8,
      src_oui=28:37:37,
      src_port=49886,
      dst_ip=104.27.129.77,
      dst_mac=10:13:31:f1:39:76,
      dst_oui=10:13:31,
      dst_port=443,
      protocol=6,
      ip_version=4,
      vlan_id=0,
      tunnel_id=0,
      bidirectional_first_seen_ms=1590680386576,
      bidirectional_last_seen_ms=1590680386576,
      bidirectional_duration_ms=0,
      bidirectional_packets=1,
      bidirectional_bytes=770,
      src2dst_first_seen_ms=1590680386576,
      src2dst_last_seen_ms=1590680386576,
      src2dst_duration_ms=0,
      src2dst_packets=1,
      src2dst_bytes=770,
      dst2src_first_seen_ms=0,
      dst2src_last_seen_ms=0,
      dst2src_duration_ms=0,
      dst2src_packets=0,
      dst2src_bytes=0,
      bidirectional_min_ps=770,
      bidirectional_mean_ps=770.0,
      bidirectional_stddev_ps=0.0,
      bidirectional_max_ps=770,
      src2dst_min_ps=770,
      src2dst_mean_ps=770.0,
      src2dst_stddev_ps=0.0,
      src2dst_max_ps=770,
      dst2src_min_ps=0,
      dst2src_mean_ps=0.0,
      dst2src_stddev_ps=0.0,
      dst2src_max_ps=0,
      bidirectional_min_piat_ms=0,
      bidirectional_mean_piat_ms=0.0,
      bidirectional_stddev_piat_ms=0.0,
      bidirectional_max_piat_ms=0,
      src2dst_min_piat_ms=0,
      src2dst_mean_piat_ms=0.0,
      src2dst_stddev_piat_ms=0.0,
      src2dst_max_piat_ms=0,
      dst2src_min_piat_ms=0,
      dst2src_mean_piat_ms=0.0,
      dst2src_stddev_piat_ms=0.0,
      dst2src_max_piat_ms=0,
      bidirectional_syn_packets=0,
      bidirectional_cwr_packets=0,
      bidirectional_ece_packets=0,
      bidirectional_urg_packets=0,
      bidirectional_ack_packets=1,
      bidirectional_psh_packets=1,
      bidirectional_rst_packets=0,
      bidirectional_fin_packets=0,
      src2dst_syn_packets=0,
      src2dst_cwr_packets=0,
      src2dst_ece_packets=0,
      src2dst_urg_packets=0,
      src2dst_ack_packets=1,
      src2dst_psh_packets=1,
      src2dst_rst_packets=0,
      src2dst_fin_packets=0,
      dst2src_syn_packets=0,
      dst2src_cwr_packets=0,
      dst2src_ece_packets=0,
      dst2src_urg_packets=0,
      dst2src_ack_packets=0,
      dst2src_psh_packets=0,
      dst2src_rst_packets=0,
      dst2src_fin_packets=0,
      application_name=TLS,
      application_category_name=Web,
      application_is_guessed=0,
      application_confidence=6,
      requested_server_name=,
      client_fingerprint=957015a0b1e2500d8777219893a09495,
      server_fingerprint=,
      user_agent=,
      content_type=,
      flow_risk={'Unidirectional Traffic': {'risk_severity': 'Low', 'risk_score_total': 500, 'risk_score_client': 430, 'risk_score_server': 70}})
```

**Test Configuration**:
* OS version: `Linux nixos-work 5.15.85 #1-NixOS SMP Wed Dec 21 16:36:38 UTC 2022 x86_64 GNU/Linux`
* Python version: 3.9.10
* Hardware: ThinkPad T14s (nothing special)

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings