### PR TITLE
Added try/except around cpu_affinity(..)

### DIFF
--- a/nfstream/utils.py
+++ b/nfstream/utils.py
@@ -141,4 +141,7 @@ def set_affinity(idx):
         c_cpus = psutil.cpu_count(logical=True)
         temp = list(chunks(range(c_cpus), 2))
         x = len(temp)
-        psutil.Process().cpu_affinity(list(temp[idx % x]))
+        try:
+            psutil.Process().cpu_affinity(list(temp[idx % x]))
+        except OSError as err:
+            print(f"WARNING: failed to set CPU affinity: {err}")


### PR DESCRIPTION
# Pull Request Template

## Description

Previously if `psutil.Process().cpu_affinity(..)` would fail it would crash the entire program. Since it is a nice-to-have feature and not strictly required it is now surrounded with a try/except block which prints a warning if it fails.

Fixes #157

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules
- [X] I have checked my code and corrected any misspellings