### PR TITLE
feat: Add pcap socket buffer size config.

### DIFF
--- a/nfstream/engine/engine.py
+++ b/nfstream/engine/engine.py
@@ -16,8 +16,8 @@ If not, see <http://www.gnu.org/licenses/>.
 from _lib_engine import ffi, lib
 
 
-def setup_capture(ffi, lib, source, snaplen, promisc, mode, error_child, group_id):
-    capture = lib.capture_open(bytes(source, 'utf-8'), int(mode), error_child)
+def setup_capture(ffi, lib, source, snaplen, promisc, mode, error_child, group_id, socket_buffer_size):
+    capture = lib.capture_open(bytes(source, 'utf-8'), int(mode), error_child, socket_buffer_size)
     if capture == ffi.NULL:
         return
     fanout_set_failed = lib.capture_set_fanout(capture, int(mode), error_child, group_id)

--- a/nfstream/engine/engine_build.py
+++ b/nfstream/engine/engine_build.py
@@ -165,7 +165,7 @@ else:
     ENGINE_SOURCE = ENGINE_INCLUDES + NDPI_MODULE_STRUCT_CDEF + ENGINE_CDEF
 ENGINE_APIS = """
 char * capture_get_interface(char * intf_name);
-pcap_t * capture_open(const uint8_t * pcap_file, int mode, char * child_error);
+pcap_t * capture_open(const char * pcap_file, int mode, char * child_error, int socket_buffer_size);
 int capture_activate(pcap_t * pcap_handle, int mode, char * child_error);
 int capture_next(pcap_t * pcap_handle, struct nf_packet *nf_pkt, int decode_tunnels, int n_roots, uint64_t root_idx,
                  int mode);

--- a/nfstream/meter.py
+++ b/nfstream/meter.py
@@ -190,7 +190,7 @@ def send_error(root_idx, channel, msg):
 
 def meter_workflow(source, snaplen, decode_tunnels, bpf_filter, promisc, n_roots, root_idx, mode,
                    idle_timeout, active_timeout, accounting_mode, udps, n_dissections, statistics, splt,
-                   channel, tracker, lock, group_id, system_visibility_mode):
+                   channel, tracker, lock, group_id, system_visibility_mode, socket_buffer_size):
     """ Metering workflow """
     set_affinity(root_idx+1)
     ffi, lib = create_engine()
@@ -223,7 +223,7 @@ def meter_workflow(source, snaplen, decode_tunnels, bpf_filter, promisc, n_roots
 
     for source_idx, source in enumerate(sources):
         error_child = ffi.new("char[256]")
-        capture = setup_capture(ffi, lib, source, snaplen, promisc, mode, error_child, group_id)
+        capture = setup_capture(ffi, lib, source, snaplen, promisc, mode, error_child, group_id, socket_buffer_size)
         if capture is None:
             send_error(root_idx, channel, ffi.string(error_child).decode('utf-8', errors='ignore'))
             return

--- a/nfstream/streamer.py
+++ b/nfstream/streamer.py
@@ -65,7 +65,8 @@ class NFStreamer(object):
                  max_nflows=0,
                  performance_report=0,
                  system_visibility_mode=0,
-                 system_visibility_poll_ms=100):
+                 system_visibility_poll_ms=100,
+                 socket_buffer_size=0):
         with NFStreamer.glock:
             NFStreamer.streamer_id += 1
             self._idx = NFStreamer.streamer_id
@@ -87,6 +88,12 @@ class NFStreamer(object):
         self.performance_report = performance_report
         self.system_visibility_mode = system_visibility_mode
         self.system_visibility_poll_ms = system_visibility_poll_ms
+
+        # NIC socket buffer size. Default is 0, which means that the pcap default value is used.
+        # The default values may vary depending on the OS and CPU architecture.
+        # Range: 0 - 2^31-1
+        self.socket_buffer_size = socket_buffer_size
+
         if NFStreamer.is_windows:
             self._mp_context = get_context("spawn")
         else:
@@ -389,7 +396,8 @@ class NFStreamer(object):
                                                              performances[i],
                                                              lock,
                                                              group_id,
-                                                             self.system_visibility_mode,)))
+                                                             self.system_visibility_mode,
+                                                             self.socket_buffer_size,)))
                 meters[i].daemon = True  # demonize meter
                 meters[i].start()
             if self._mode == NFMode.INTERFACE and self.performance_report > 0:


### PR DESCRIPTION
# Pull Request Template

## Description

Update 'capture_open' function in 'lib_engine.c' to support setting socket buffer size in INTERFACE mode. Use 'MODE_INTERFACE' constant and consistently use 'char*' type in the function. Add 'socket_buffer_size' attribute to NFStreamer for the same purpose.

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## How Has This Been Tested?

After executing app.py and monitoring its memory usage on btop to check if it reaches the buffer size I set, I have also confirmed a significant reduction in the number of packets dropped by the kernel.

app.py:
```python
import os
from nfstream import NFStreamer

my_streamer = NFStreamer(
    source="enp7s0f0",
    decode_tunnels=True,
    bpf_filter=None,
    promiscuous_mode=True,
    snapshot_length=1536,
    idle_timeout=0,
    active_timeout=1800,
    accounting_mode=0,
    udps=None,
    n_dissections=20,
    statistical_analysis=True,
    splt_analysis=10,
    n_meters=4,
    max_nflows=0,
    performance_report=1,
    socket_buffer_size=(2048*1024*1024-1),
)

def main():
    for flow in my_streamer:
        # print(flow)
        pass

if __name__ == "__main__":
    if os.geteuid() != 0:
        print("Need use sudo to run script.")
        exit(1)
    main()
```

**Test Configuration**:
* OS version: Linux 5.19.0-32-generic 22.04.1-Ubuntu x86_64
* Python version: 3.11.2
* Hardware:
  + CPU: Intel i7-13700kf
  + RAM: DDR4-32GB-3200

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings