### PR TITLE
Customizable Performance Report

### DIFF
--- a/nfstream/meter.py
+++ b/nfstream/meter.py
@@ -178,9 +178,11 @@ def meter_cleanup(cache, channel, udps, sync, n_dissections, statistics, splt, f
 def capture_track(lib, capture, mode, interface_stats, tracker, processed, ignored):
     """ Update shared performance values """
     lib.capture_stats(capture, interface_stats, mode)
-    tracker[0].value = interface_stats.dropped
-    tracker[1].value = processed
-    tracker[2].value = ignored
+    tracker["received"].value = interface_stats.received
+    tracker["dropped"].value = interface_stats.dropped
+    tracker["dropped_if"].value = interface_stats.dropped_by_interface
+    tracker["processed"].value = processed
+    tracker["ignored"].value = ignored
 
 
 def send_error(root_idx, channel, msg):

--- a/nfstream/streamer.py
+++ b/nfstream/streamer.py
@@ -26,7 +26,7 @@ from .meter import meter_workflow
 from .anonymizer import NFAnonymizer
 from .engine import is_interface
 from .plugin import NFPlugin
-from .utils import csv_converter, open_file, RepeatedTimer, PerformanceStats, update_performances, set_affinity, available_cpus_count
+from .utils import csv_converter, open_file, RepeatedTimer, PerformanceStats, set_affinity, available_cpus_count
 from .utils import validate_flows_per_file, NFMode, create_csv_file_path, NFEvent, validate_rotate_files
 from .system import system_socket_worflow, match_flow_conn
 
@@ -65,6 +65,7 @@ class NFStreamer(object):
                  n_meters=0,
                  max_nflows=0,
                  performance_report=0,
+                 performance_stats=PerformanceStats,
                  system_visibility_mode=0,
                  system_visibility_poll_ms=100):
         with NFStreamer.glock:
@@ -86,6 +87,7 @@ class NFStreamer(object):
         self.n_meters = n_meters
         self.max_nflows = max_nflows
         self.performance_report = performance_report
+        self.performance_stats = performance_stats
         self.system_visibility_mode = system_visibility_mode
         self.system_visibility_poll_ms = system_visibility_poll_ms
 
@@ -372,7 +374,10 @@ class NFStreamer(object):
         # multiprocessing Value invocation must be performed before the call to Queue.
         n_meters = self.n_meters
         idx_generator = self._mp_context.Value('i', 0)
-        performances = PerformanceStats(n_meters, self._mp_context)
+        performances = self.performance_stats(n_meters,
+                                              self._mp_context,
+                                              True if platform.system() == "Linux" else False,
+                                              idx_generator)
         channel = self._mp_context.Queue(maxsize=32767)  # Backpressure strategy.
         #                                                  We set it to (2^15-1) to cope with OSX max semaphore value.
         group_id = os.getpid() + self._idx  # Used for fanout on Linux systems
@@ -403,10 +408,7 @@ class NFStreamer(object):
                 meters[i].daemon = True  # demonize meter
                 meters[i].start()
             if self._mode == NFMode.INTERFACE and self.performance_report > 0:
-                if platform.system() == "Linux":
-                    rt = RepeatedTimer(self.performance_report, update_performances, performances, True, idx_generator)
-                else:
-                    rt = RepeatedTimer(self.performance_report, update_performances, performances, False, idx_generator)
+                rt = RepeatedTimer(self.performance_report, performances.update_performances)
             if self._mode == NFMode.INTERFACE and self.system_visibility_mode:
                 socket_listener = self._mp_context.Process(target=system_socket_worflow,
                                                            args=(channel,

--- a/nfstream/streamer.py
+++ b/nfstream/streamer.py
@@ -26,7 +26,7 @@ from .meter import meter_workflow
 from .anonymizer import NFAnonymizer
 from .engine import is_interface
 from .plugin import NFPlugin
-from .utils import csv_converter, open_file, RepeatedTimer, update_performances, set_affinity, available_cpus_count
+from .utils import csv_converter, open_file, RepeatedTimer, PerformanceStats, update_performances, set_affinity, available_cpus_count
 from .utils import validate_flows_per_file, NFMode, create_csv_file_path, NFEvent, validate_rotate_files
 from .system import system_socket_worflow, match_flow_conn
 
@@ -361,7 +361,6 @@ class NFStreamer(object):
         lock = self._mp_context.Lock()
         lock.acquire()
         meters = []
-        performances = []
         n_terminated = 0
         child_error = None
         rt = None
@@ -373,10 +372,7 @@ class NFStreamer(object):
         # multiprocessing Value invocation must be performed before the call to Queue.
         n_meters = self.n_meters
         idx_generator = self._mp_context.Value('i', 0)
-        for i in range(n_meters):
-            performances.append([self._mp_context.Value('I', 0),
-                                 self._mp_context.Value('I', 0),
-                                 self._mp_context.Value('I', 0)])
+        performances = PerformanceStats(n_meters, self._mp_context)
         channel = self._mp_context.Queue(maxsize=32767)  # Backpressure strategy.
         #                                                  We set it to (2^15-1) to cope with OSX max semaphore value.
         group_id = os.getpid() + self._idx  # Used for fanout on Linux systems

--- a/nfstream/utils.py
+++ b/nfstream/utils.py
@@ -83,25 +83,53 @@ def open_file(path, chunked, chunk_idx, rotate_files):
         return open(path.replace("csv", "{}.csv".format(chunk_idx)), 'wb')
 
 
+class PerformanceStats:
+    """ Store all meter performance stats """
+
+    def __init__(self, n_meters, context):
+        self.performances = []
+        for _ in range(n_meters):
+            self.performances.append(
+                {
+                    "received": context.Value("I", 0),
+                    "dropped": context.Value("I", 0),
+                    "dropped_if": context.Value("I", 0),
+                    "processed": context.Value("I", 0),
+                    "ignored": context.Value("I", 0),
+                }
+            )
+
+    def __getitem__(self, idx):
+        return self.performances[idx]
+
+
 def update_performances(performances, is_linux, flows_count):
     """ Update performance report and check platform for consistency """
+    received = 0
     drops = 0
+    drops_if = 0
     processed = 0
     ignored = 0
     load = []
     for meter in performances:
         if is_linux:
-            drops += meter[0].value
-            ignored += meter[2].value
+            received += meter["received"].value
+            drops += meter["dropped"].value
+            drops_if += meter["dropped_if"].value
+            ignored += meter["ignored"].value
         else:
-            drops = max(meter[0].value, drops)
-            ignored = max(meter[2].value, ignored)
-        processed += meter[1].value
-        load.append(meter[1].value)
+            received = max(meter["received"].value, received)
+            drops = max(meter["dropped"].value, drops)
+            drops_if = max(meter["dropped_if"].value, drops_if)
+            ignored = max(meter["ignored"].value, ignored)
+        processed += meter["processed"].value
+        load.append(meter["processed"].value)
     print(json.dumps({"flows_expired": flows_count.value,
+                      "packets_received": received,
                       "packets_processed": processed,
                       "packets_ignored": ignored,
                       "packets_dropped_filtered_by_kernel": drops,
+                      "packets_dropped_filtered_by_interface": drops_if,
                       "meters_packets_processing_balance": load}))
 
 

--- a/nfstream/utils.py
+++ b/nfstream/utils.py
@@ -108,7 +108,7 @@ class PerformanceStats:
         return self.performances[idx]
 
     def update_performances(self):
-        """ Update performance report and check platform for consistency """
+        """ Update performance report """
         received = 0
         drops = 0
         drops_if = 0

--- a/nfstream/utils.py
+++ b/nfstream/utils.py
@@ -84,9 +84,14 @@ def open_file(path, chunked, chunk_idx, rotate_files):
 
 
 class PerformanceStats:
-    """ Store all meter performance stats """
+    """ Store all meter performance stats, `update_performances()` will be called if `NFStreamer`'s
+    `performance_report` is set to non-zero value.
+    
+    Inherit this class and override `update_performances()` for custom log format. """
 
-    def __init__(self, n_meters, context):
+    def __init__(self, n_meters, context, is_linux, flows_count):
+        self.is_linux = is_linux
+        self.flows_count = flows_count
         self.performances = []
         for _ in range(n_meters):
             self.performances.append(
@@ -102,35 +107,34 @@ class PerformanceStats:
     def __getitem__(self, idx):
         return self.performances[idx]
 
-
-def update_performances(performances, is_linux, flows_count):
-    """ Update performance report and check platform for consistency """
-    received = 0
-    drops = 0
-    drops_if = 0
-    processed = 0
-    ignored = 0
-    load = []
-    for meter in performances:
-        if is_linux:
-            received += meter["received"].value
-            drops += meter["dropped"].value
-            drops_if += meter["dropped_if"].value
-            ignored += meter["ignored"].value
-        else:
-            received = max(meter["received"].value, received)
-            drops = max(meter["dropped"].value, drops)
-            drops_if = max(meter["dropped_if"].value, drops_if)
-            ignored = max(meter["ignored"].value, ignored)
-        processed += meter["processed"].value
-        load.append(meter["processed"].value)
-    print(json.dumps({"flows_expired": flows_count.value,
-                      "packets_received": received,
-                      "packets_processed": processed,
-                      "packets_ignored": ignored,
-                      "packets_dropped_filtered_by_kernel": drops,
-                      "packets_dropped_filtered_by_interface": drops_if,
-                      "meters_packets_processing_balance": load}))
+    def update_performances(self):
+        """ Update performance report and check platform for consistency """
+        received = 0
+        drops = 0
+        drops_if = 0
+        processed = 0
+        ignored = 0
+        load = []
+        for meter in self.performances:
+            if self.is_linux:
+                received += meter["received"].value
+                drops += meter["dropped"].value
+                drops_if += meter["dropped_if"].value
+                ignored += meter["ignored"].value
+            else:
+                received = max(meter["received"].value, received)
+                drops = max(meter["dropped"].value, drops)
+                drops_if = max(meter["dropped_if"].value, drops_if)
+                ignored = max(meter["ignored"].value, ignored)
+            processed += meter["processed"].value
+            load.append(meter["processed"].value)
+        print(json.dumps({"flows_expired": self.flows_count.value,
+                          "packets_received": received,
+                          "packets_processed": processed,
+                          "packets_ignored": ignored,
+                          "packets_dropped_filtered_by_kernel": drops,
+                          "packets_dropped_filtered_by_interface": drops_if,
+                          "meters_packets_processing_balance": load}))
 
 
 class RepeatedTimer(object):


### PR DESCRIPTION
# Customizable Performance Report

## Description

1. Add `received`, `dropped_by_interface` from `struct nf_stat` to `NFStreamer`'s performance report
2. Add a new class `PerformanceStats` in `utils.py` and make `update_performances()` into its own method.

Customize performance report by inheriting `PerformanceStats` and override `update_performances()`

Related #147

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

## How Has This Been Tested?

**Test Configuration**:
* OS version: Ubuntu 22.04.2 LTS
* Python version: 3.11.0rc1
* Hardware: Proxmox VE virtual machine on i3-8350k, 16GB ram.

Example code:
```python
from nfstream import NFStreamer
from nfstream.utils import PerformanceStats


class CustomStats(PerformanceStats):
    def update_performances(self):
        received = 0
        drops = 0
        drops_if = 0
        processed = 0
        ignored = 0
        for meter in self.performances:
            received += meter["received"].value
            drops += meter["dropped"].value
            drops_if += meter["dropped_if"].value
            ignored += meter["ignored"].value
            processed += meter["processed"].value

        print(
            "received: {}, drop: {}, drop_if: {}, ignored: {}, processed: {}, debt: {}".format(
                received,
                drops,
                drops_if,
                ignored,
                processed,
                received - (drops + drops_if + ignored + processed),
            )
        )


def main():
    # streamer_default_logs = NFStreamer(
    #     source="ens18",
    #     idle_timeout=5,
    #     n_meters=2,
    #     performance_report=1,
    # )

    streamer_custom_logs = NFStreamer(
        source="ens18",
        idle_timeout=5,
        n_meters=2,
        performance_report=1,
        performance_stats=CustomStats,
    )

    for flow in streamer_custom_logs:
        pass


if __name__ == "__main__":
    main()

```

default log output:
```bash
{"flows_expired": 0, "packets_received": 0, "packets_processed": 0, "packets_ignored": 0, "packets_dropped_filtered_by_kernel": 0, "packets_dropped_filtered_by_interface": 0, "meters_packets_processing_balance": [0, 0]}
{"flows_expired": 0, "packets_received": 8, "packets_processed": 1, "packets_ignored": 0, "packets_dropped_filtered_by_kernel": 0, "packets_dropped_filtered_by_interface": 0, "meters_packets_processing_balance": [0, 1]}
{"flows_expired": 0, "packets_received": 14, "packets_processed": 10, "packets_ignored": 0, "packets_dropped_filtered_by_kernel": 0, "packets_dropped_filtered_by_interface": 0, "meters_packets_processing_balance": [0, 10]}
{"flows_expired": 0, "packets_received": 36, "packets_processed": 15, "packets_ignored": 0, "packets_dropped_filtered_by_kernel": 0, "packets_dropped_filtered_by_interface": 0, "meters_packets_processing_balance": [0, 15]}
{"flows_expired": 0, "packets_received": 69, "packets_processed": 43, "packets_ignored": 0, "packets_dropped_filtered_by_kernel": 0, "packets_dropped_filtered_by_interface": 0, "meters_packets_processing_balance": [0, 43]}
{"flows_expired": 0, "packets_received": 104, "packets_processed": 102, "packets_ignored": 0, "packets_dropped_filtered_by_kernel": 0, "packets_dropped_filtered_by_interface": 0, "meters_packets_processing_balance": [0, 102]}
{"flows_expired": 0, "packets_received": 109, "packets_processed": 108, "packets_ignored": 0, "packets_dropped_filtered_by_kernel": 0, "packets_dropped_filtered_by_interface": 0, "meters_packets_processing_balance": [0, 108]}
{"flows_expired": 0, "packets_received": 114, "packets_processed": 113, "packets_ignored": 0, "packets_dropped_filtered_by_kernel": 0, "packets_dropped_filtered_by_interface": 0, "meters_packets_processing_balance": [0, 113]}
{"flows_expired": 0, "packets_received": 116, "packets_processed": 115, "packets_ignored": 0, "packets_dropped_filtered_by_kernel": 0, "packets_dropped_filtered_by_interface": 0, "meters_packets_processing_balance": [0, 115]}
{"flows_expired": 0, "packets_received": 124, "packets_processed": 119, "packets_ignored": 0, "packets_dropped_filtered_by_kernel": 0, "packets_dropped_filtered_by_interface": 0, "meters_packets_processing_balance": [0, 119]}
{"flows_expired": 0, "packets_received": 132, "packets_processed": 129, "packets_ignored": 0, "packets_dropped_filtered_by_kernel": 0, "packets_dropped_filtered_by_interface": 0, "meters_packets_processing_balance": [0, 129]}
{"flows_expired": 0, "packets_received": 136, "packets_processed": 135, "packets_ignored": 0, "packets_dropped_filtered_by_kernel": 0, "packets_dropped_filtered_by_interface": 0, "meters_packets_processing_balance": [0, 135]}
{"flows_expired": 0, "packets_received": 141, "packets_processed": 139, "packets_ignored": 1, "packets_dropped_filtered_by_kernel": 0, "packets_dropped_filtered_by_interface": 0, "meters_packets_processing_balance": [0, 139]}
{"flows_expired": 0, "packets_received": 143, "packets_processed": 141, "packets_ignored": 1, "packets_dropped_filtered_by_kernel": 0, "packets_dropped_filtered_by_interface": 0, "meters_packets_processing_balance": [0, 141]}
{"flows_expired": 0, "packets_received": 151, "packets_processed": 143, "packets_ignored": 1, "packets_dropped_filtered_by_kernel": 0, "packets_dropped_filtered_by_interface": 0, "meters_packets_processing_balance": [0, 143]}
{"flows_expired": 0, "packets_received": 155, "packets_processed": 151, "packets_ignored": 1, "packets_dropped_filtered_by_kernel": 0, "packets_dropped_filtered_by_interface": 0, "meters_packets_processing_balance": [0, 151]}
...
```

custom log output:
```bash
received: 0, drop: 0, drop_if: 0, ignored: 0, processed: 0, debt: 0
received: 1, drop: 0, drop_if: 0, ignored: 0, processed: 1, debt: 0
received: 5, drop: 0, drop_if: 0, ignored: 0, processed: 5, debt: 0
received: 8, drop: 0, drop_if: 0, ignored: 0, processed: 7, debt: 1
received: 14, drop: 0, drop_if: 0, ignored: 0, processed: 13, debt: 1
received: 20, drop: 0, drop_if: 0, ignored: 0, processed: 19, debt: 1
received: 22, drop: 0, drop_if: 0, ignored: 0, processed: 21, debt: 1
received: 24, drop: 0, drop_if: 0, ignored: 0, processed: 23, debt: 1
received: 26, drop: 0, drop_if: 0, ignored: 0, processed: 25, debt: 1
received: 33, drop: 0, drop_if: 0, ignored: 0, processed: 31, debt: 2
received: 38, drop: 0, drop_if: 0, ignored: 0, processed: 37, debt: 1
...
```

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings