### PR TITLE
Extended splt_analysis parameter to allow up to 65535 values

### DIFF
--- a/nfstream/engine/engine_build.py
+++ b/nfstream/engine/engine_build.py
@@ -167,13 +167,13 @@ void dissector_configure(struct ndpi_detection_module_struct *dissector);
 void dissector_cleanup(struct ndpi_detection_module_struct *dissector);
 
 struct nf_flow *meter_initialize_flow(struct nf_packet *packet, uint8_t accounting_mode, uint8_t statistics,
-                                      uint8_t splt, uint8_t n_dissections,
+                                      uint16_t splt, uint8_t n_dissections,
                                       struct ndpi_detection_module_struct *dissector, uint8_t sync);
 uint8_t meter_update_flow(struct nf_flow *flow, struct nf_packet *packet, uint64_t idle_timeout, uint64_t active_timeout,
-                          uint8_t accounting_mode, uint8_t statistics, uint8_t splt, uint8_t n_dissections,
+                          uint8_t accounting_mode, uint8_t statistics, uint16_t splt, uint8_t n_dissections,
                           struct ndpi_detection_module_struct *dissector, uint8_t sync);
 void meter_expire_flow(struct nf_flow *flow, uint8_t n_dissections, struct ndpi_detection_module_struct *dissector);
-void meter_free_flow(struct nf_flow *flow, uint8_t n_dissections, uint8_t splt, uint8_t full);
+void meter_free_flow(struct nf_flow *flow, uint8_t n_dissections, uint16_t splt, uint8_t full);
 const char *engine_lib_version(void);
 const char *engine_lib_ndpi_version(void);
 const char *engine_lib_pcap_version(void);

--- a/nfstream/engine/lib_engine.c
+++ b/nfstream/engine/lib_engine.c
@@ -985,7 +985,7 @@ static uint8_t flow_expiration_handler(struct nf_flow *flow, struct nf_packet *p
 /**
  * flow_init_splt: Flow SPLT structure initializer.
  */
-static uint8_t flow_init_splt(struct nf_flow *flow, uint8_t splt, uint16_t packet_size) {
+static uint8_t flow_init_splt(struct nf_flow *flow, uint16_t splt, uint16_t packet_size) {
   flow->splt_direction = (int8_t*)ndpi_malloc(sizeof(int8_t) * splt); // direction on int8 is more than sufficient.
   if (flow->splt_direction == NULL) {
     ndpi_free(flow);
@@ -1016,7 +1016,7 @@ static uint8_t flow_init_splt(struct nf_flow *flow, uint8_t splt, uint16_t packe
 /**
  * flow_update_splt: Flow SPLT structure updater.
  */
-static void flow_update_splt(uint8_t splt, struct nf_flow *flow, struct nf_packet *packet, uint16_t packet_size,
+static void flow_update_splt(uint16_t splt, struct nf_flow *flow, struct nf_packet *packet, uint16_t packet_size,
                              uint64_t bidirectional_piat_ms) {
   if ((flow->bidirectional_packets - 1) < splt) {
       flow->splt_direction[flow->bidirectional_packets - 1] = packet->direction;
@@ -1252,7 +1252,7 @@ static void flow_update_dst2src_piat_ms(struct nf_flow *flow, uint64_t dst2src_p
  * flow_init_bidirectional: Flow bidirectional initializer.
  */
 static uint8_t flow_init_bidirectional(struct ndpi_detection_module_struct *dissector, uint8_t n_dissections,
-                                       uint8_t splt, uint8_t statistics, uint16_t packet_size, struct nf_flow *flow,
+                                       uint16_t splt, uint8_t statistics, uint16_t packet_size, struct nf_flow *flow,
                                        struct nf_packet *packet, uint8_t sync) {
   if (splt) {
     uint8_t splt_init_success = flow_init_splt(flow, splt, packet_size);
@@ -1316,7 +1316,7 @@ static uint8_t flow_init_bidirectional(struct ndpi_detection_module_struct *diss
 /**
  * flow_update_bidirectional: Flow bidirectional updater.
  */
-static void flow_update_bidirectional(struct ndpi_detection_module_struct *dissector, uint8_t n_dissections, uint8_t splt,
+static void flow_update_bidirectional(struct ndpi_detection_module_struct *dissector, uint8_t n_dissections, uint16_t splt,
                                uint8_t statistics, uint16_t packet_size, struct nf_flow *flow,
                                struct nf_packet *packet, uint8_t sync) {
   uint64_t bidirectional_piat_ms = packet->time - flow->bidirectional_last_seen_ms;
@@ -1679,7 +1679,7 @@ void dissector_cleanup(struct ndpi_detection_module_struct *dissector) {
  * meter_initialize_flow: Initialize flow based on packet values and set packet direction.
  */
 struct nf_flow *meter_initialize_flow(struct nf_packet *packet, uint8_t accounting_mode, uint8_t statistics,
-                                      uint8_t splt, uint8_t n_dissections,
+                                      uint16_t splt, uint8_t n_dissections,
                                       struct ndpi_detection_module_struct *dissector, uint8_t sync) {
   struct nf_flow *flow = (struct nf_flow*)ndpi_malloc(sizeof(struct nf_flow));
   if (flow == NULL) return NULL; // not enough memory for flow.
@@ -1698,7 +1698,7 @@ struct nf_flow *meter_initialize_flow(struct nf_packet *packet, uint8_t accounti
  * meter_update_flow: Check expiration state, and update flow based on packet values if case of active one.
  */
 uint8_t meter_update_flow(struct nf_flow *flow, struct nf_packet *packet, uint64_t idle_timeout, uint64_t active_timeout,
-                          uint8_t accounting_mode, uint8_t statistics, uint8_t splt, uint8_t n_dissections,
+                          uint8_t accounting_mode, uint8_t statistics, uint16_t splt, uint8_t n_dissections,
                           struct ndpi_detection_module_struct *dissector, uint8_t sync) {
   uint8_t expired = flow_expiration_handler(flow, packet, idle_timeout, active_timeout);
   if (expired) return expired;
@@ -1726,7 +1726,7 @@ void meter_expire_flow(struct nf_flow *flow, uint8_t n_dissections, struct ndpi_
 /**
  * meter_free_flow: Flow structure freer.
  */
-void meter_free_flow(struct nf_flow *flow, uint8_t n_dissections, uint8_t splt, uint8_t full) {
+void meter_free_flow(struct nf_flow *flow, uint8_t n_dissections, uint16_t splt, uint8_t full) {
   if (full) {
     if (n_dissections) flow_free_ndpi_data(flow);
     if (splt) flow_free_splt_data(flow);

--- a/nfstream/streamer.py
+++ b/nfstream/streamer.py
@@ -262,8 +262,10 @@ class NFStreamer(object):
 
     @splt_analysis.setter
     def splt_analysis(self, value):
-        if not isinstance(value, int) or (value < 0 or value > 255):
-            raise ValueError("Please specify a valid splt_analysis parameter (possible values in : [0,...,255])")
+        if not isinstance(value, int) or (value < 0 or value > 65535):
+            raise ValueError("Please specify a valid splt_analysis parameter (possible values in : [0,...,65535])")
+        if value > 255:
+            print("[WARNING]: The specified splt_analysis parameter is higher than 255. High values can impact the performance of the tool.")
         self._splt_analysis = value
 
     @property

--- a/tests.py
+++ b/tests.py
@@ -219,7 +219,7 @@ class NFStreamTest(object):
     def test_splt_analysis_parameter():
         print("\n----------------------------------------------------------------------")
         n_exceptions = 0
-        splt_analysis = [-1, 256, "yes"]
+        splt_analysis = [-1, 70000, "yes"]
         for x in splt_analysis:
             try:
                 NFStreamer(source=os.path.join("tests", "pcaps", "google_ssl.pcap"), splt_analysis=x)


### PR DESCRIPTION
# Extend splt_analysis parameter to allow up to 65535 values

## Description

- Updated the setter for the `splt_analysis` parameter to allow values up to 65535 instead of the previous limit of 255.
- Added a warning message for values above 255 due to potential performance implications.
- Updated the `test_splt_analysis_parameter` method to reflect the extended valid range for `splt_analysis`.

This change allows users to specify a larger number of packet dissections for NFStream, enabling more detailed analysis where needed, while also informing them of potential performance impacts.

## Type of change

Please delete options that are not relevant.

- [X] **Enhancement**
- [X] **This change requires a documentation update**

## How Has This Been Tested?

- [X] Tested via the included `test.py` script (also updated it to reflect the enhancement).
- [X] Tested it via running in both live and offline modes.

**Test Configuration**:
* OS version: MacOS 12.6.7 (21G651)
* Python version: 3.11.4
* Hardware: MacBook Air Early 2015

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] **My changes generate no new warnings** It does, however, it is rather a notification for the user.
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules
- [X] I have checked my code and corrected any misspellings