### PR TITLE
Fixed TCP flow expiration when a user plugin forcibly expires the flow on the first packet

### DIFF
--- a/nfstream/meter.py
+++ b/nfstream/meter.py
@@ -138,6 +138,11 @@ def consume(packet, cache, active_timeout, idle_timeout, channel, ffi, lib, udps
                 try:
                     cache[flow_key] = NFlow(packet, ffi, lib, udps, sync, accounting_mode, n_dissections,
                                             statistics, splt, dissector, decode_tunnels, system_visibility_mode)
+                    if cache[flow_key].expiration_id == -1:  # A user Plugin forced expiration on the first packet
+                        channel.put(
+                            cache[flow_key].expire(udps, sync, n_dissections, statistics, splt, ffi, lib, dissector))
+                        del cache[flow_key]
+                        state = 0
                 except OSError:
                     print("WARNING: Failed to allocate memory space for flow creation. Flow creation aborted.")
                 state = 0


### PR DESCRIPTION
# TCP flow expiration fix

## Description

This PR fixes TCP flow expiration when a user plugin forcibly expires the flow on the first packet. 

Before this PR, if a flow with the same 5-tuple was previously expired by active/idle timeout, a new entry was created. But then, an updated was also called before udps expiration could be checked. This way, a create and then an update was called, resulting in the effect that although a user plugin was expecting the flow to be expired at first TCP flag seen, some flows expired with two flags observed in the flow.

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

The fixed version of NFStream was tested using the supplied test script of NFStream. It was additionally tested with a PCAP with various TCP flag counts to validate the PR fixes the issue.

**Test Configuration**:
* OS version: MacOS and Ubuntu
* Python version: 3.11.4 and 3.10.12
* Hardware: Macbook and VMWare virtual machine

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [  ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [  ] I have added tests that prove my fix is effective or that my feature works
- [  ] New and existing unit tests pass locally with my changes
- [  ] Any dependent changes have been merged and published in downstream modules
- [X] I have checked my code and corrected any misspellings