### PR TITLE
transport layer size calculation fix

### DIFF
--- a/nfstream/__init__.py
+++ b/nfstream/__init__.py
@@ -21,4 +21,4 @@ from .plugin import NFPlugin
 # streamer module is the core module of nfstream package.
 __author__ = """Zied Aouini"""
 __email__ = "aouinizied@gmail.com"
-__version__ = "6.5.4"
+__version__ = "6.5.5"

--- a/nfstream/engine/lib_engine.c
+++ b/nfstream/engine/lib_engine.c
@@ -211,7 +211,7 @@ static void packet_get_tcp_info(const uint8_t *l4, uint16_t l4_packet_len, struc
   tcp_len = ndpi_min(4*(*tcph)->doff, l4_packet_len);
   *payload = (uint8_t*)&l4[tcp_len];
   *payload_len = ndpi_max(0, l4_packet_len-4*(*tcph)->doff);
-  *l4_data_len = l4_packet_len - sizeof(struct ndpi_tcphdr);
+  *l4_data_len = l4_packet_len;
   nf_pkt->fin = (*tcph)->fin;
   nf_pkt->syn = (*tcph)->syn;
   nf_pkt->rst = (*tcph)->rst;
@@ -232,7 +232,7 @@ static void packet_get_udp_info(const uint8_t *l4, uint16_t l4_packet_len, struc
   *sport = (*udph)->source, *dport = (*udph)->dest;
   *payload = (uint8_t*)&l4[sizeof(struct ndpi_udphdr)];
   *payload_len = (l4_packet_len > sizeof(struct ndpi_udphdr)) ? l4_packet_len-sizeof(struct ndpi_udphdr) : 0;
-  *l4_data_len = l4_packet_len - sizeof(struct ndpi_udphdr);
+  *l4_data_len = l4_packet_len;
   nf_pkt->fin = nf_pkt->syn = nf_pkt->rst = nf_pkt->psh = nf_pkt->ack = nf_pkt->urg = nf_pkt->ece = nf_pkt->cwr = 0;
 }
 
@@ -243,7 +243,7 @@ static void packet_get_icmp_info(const uint8_t *l4, uint16_t l4_packet_len, stru
                           uint16_t *dport, uint32_t *l4_data_len, uint8_t **payload, uint16_t *payload_len) {
   *payload = (uint8_t*)&l4[sizeof(struct ndpi_icmphdr )];
   *payload_len = (l4_packet_len > sizeof(struct ndpi_icmphdr)) ? l4_packet_len-sizeof(struct ndpi_icmphdr) : 0;
-  *l4_data_len = l4_packet_len - sizeof(struct ndpi_icmphdr);
+  *l4_data_len = l4_packet_len;
   *sport = *dport = 0;
   nf_pkt->fin = nf_pkt->syn = nf_pkt->rst = nf_pkt->psh = nf_pkt->ack = nf_pkt->urg = nf_pkt->ece = nf_pkt->cwr = 0;
 }
@@ -255,7 +255,7 @@ static void packet_get_icmp6_info(const uint8_t *l4, uint16_t l4_packet_len, str
                            uint16_t *dport, uint32_t *l4_data_len, uint8_t **payload, uint16_t *payload_len) {
   *payload = (uint8_t*)&l4[sizeof(struct ndpi_icmp6hdr)];
   *payload_len = (l4_packet_len > sizeof(struct ndpi_icmp6hdr)) ? l4_packet_len-sizeof(struct ndpi_icmp6hdr) : 0;
-  *l4_data_len = l4_packet_len - sizeof(struct ndpi_icmp6hdr);
+  *l4_data_len = l4_packet_len;
   *sport = *dport = 0;
   nf_pkt->fin = nf_pkt->syn = nf_pkt->rst = nf_pkt->psh = nf_pkt->ack = nf_pkt->urg = nf_pkt->ece = nf_pkt->cwr = 0;
 }


### PR DESCRIPTION
# Fixes to Transport Layer Size Calculations**

This PR addresses inconsistencies and ambiguities in the size calculations for UDP and TCP protocols in NFStream, specifically regarding `transport_size` (accounting mode 2) and `payload_size` (accounting mode 3). Additionally, the fixes ensure alignment with ICMP and ICMPv6 calculations for consistency across all protocols.

---

## **1. Fix for UDP**

### **Observation**
When accounting mode was set to:
- **Mode 2** (transport size): Returned the same value as mode 3 (payload size).
- **Mode 3** (payload size): Represented the payload-only size (excluding the header).

This rendered mode 2 redundant, as it was essentially duplicating mode 3. I believe the original intent was to keep the UDP header length in the size value, not to subtract it.

### **Fix**
- `transport_size` (accounting mode 2): Now includes the UDP header along with the payload.
- `payload_size` (accounting mode 3): Remains unchanged and represents the payload-only size, excluding the UDP header.

### **Why This Fix Is Better**
- **Functional Distinction**: Restores the intended functionality of mode 2 by including the header size.

---

## **2. Fix for TCP**

### **Observation**
The original implementation calculated sizes as follows:
- **Mode 2** (transport size): Excluded the base TCP header (20 bytes) **but included any TCP options** (e.g., 12 bytes if present).
- **Mode 3** (payload size): Represented only the raw data size, excluding both the header and options.

This approach created ambiguity, especially since:
1. TCP options are not fixed in size and can vary.
2. Users could not infer the presence or size of options based on these metrics.

### **Fix**
- `transport_size` (accounting mode 2): Now includes the entire TCP segment (base header + options + payload), ensuring that the full transport size is reported.
- `payload_size` (accounting mode 3): Continues to represent the raw payload size, excluding all headers.

### **Why This Fix Is Better**
- **Consistency with UDP**: Ensures both TCP and UDP `transport_size` include their respective headers.
- **Improved Analysis**: Users no longer need to account for header or options manually, simplifying flow analysis.
- **Allows for calculating TCP Options size**:  
  1. Calculate the size using accounting mode `2` (transport size).
  2. Recalculate using accounting mode `3` (payload size).
  3. If the difference is 32, subtracting the 20 bytes base (fixed) will give the 12 options bytes.

---

## **3. Extension to ICMP and ICMPv6**

### **Observation**
Previously, `transport_size` calculations for ICMP and ICMPv6 also excluded their respective headers.

### **Fix**
- `transport_size` now includes the header size for both ICMP and ICMPv6.
- `payload_size` continues to represent only the data payload.

This ensures all protocols (TCP, UDP, ICMP, ICMPv6) follow a unified metric definition, simplifying analysis.

---

## Type of change

- [x ] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

A simple PCAP with TCP/UDP flows is enough for testing and comparison. Having TCP options is preferred. Testing focused on examining the sizes before and after the fix. The included `test.py` was also run to verify the fix does not break anything.