### PR TITLE
Fix DLT_RAW processing: correctly set EtherType for raw IP packets

### DIFF
--- a/nfstream/engine/lib_engine.c
+++ b/nfstream/engine/lib_engine.c
@@ -604,6 +604,13 @@ static int packet_datalink_checker(uint32_t caplen, const uint8_t *packet, uint1
     break;
   case DLT_RAW:
     (*ip_offset) = eth_offset;
+    if (caplen > eth_offset) { // Raw IP (DLT_RAW) can carry either IPv4 or IPv6 packets, so let's check it 
+        uint8_t ver = packet[eth_offset] >> 4;
+        if (ver == 4)
+            *type = ETH_P_IP;
+        else if (ver == 6)
+            *type = ETH_P_IPV6;
+    }
     break;
   default:
     return 0;


### PR DESCRIPTION
## Description

In many monitoring environments, especially when using high-performance capture interfaces or certain operating systems, the packet capture interface may deliver packets with the DLT_RAW data link type. In these cases, the capture does not include an Ethernet header, and the packet data consists solely of the IP header (and its payload). This is a common and valid scenario for network monitoring and flow analysis.

## The Issue
When processing DLT_RAW packets, NFStream previously did not set the packet “type” (i.e. the EtherType) based on the actual IP version present in the raw data. As a result:

1. **Fragment Misprocessing:**  
   Because the *type variable was never set, the fragment-checking code (which requires *type to be ETH_P_IP for IPv4) was not executed. Consequently, non-first fragments—lacking complete transport headers—were processed as if they were full packets. Their incomplete header data was misinterpreted as valid transport-layer information (e.g. UDP source/destination ports), leading to erroneous flow creation.

2. **Bogus Flow Generation:**  
   In my test [PCAP](https://github.com/user-attachments/files/18725025/sample.pcap.zip), although only two actual flows existed, over 51 flows appeared in the CSV output. Each additional flow represented a later fragment that was misprocessed. The port numbers for these bogus flows were derived by interpreting fragment payload data at the offset where a UDP header is expected. This clearly skews the monitoring results.

## The Fix
The fix modifies the DLT_RAW case in `packet_datalink_checker()` (located in `lib_engine.c`) to inspect the first byte of the packet to determine its IP version, and then set *type accordingly. This ensures that subsequent processing—such as fragment checking—works correctly. 

## Type of change

- [x ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How Has This Been Tested?

The test was performed using the attached [PCAP](https://github.com/user-attachments/files/18725025/sample.pcap.zip) file.