### PR TITLE
Fix IPv6 accounting mode consistency with IPv4

### DIFF
--- a/nfstream/engine/lib_engine.c
+++ b/nfstream/engine/lib_engine.c
@@ -387,7 +387,7 @@ static int packet_get_ipv6_info(uint16_t vlan_id, ndpi_packet_tunnel tunnel_id,
     return 0;
   }
   iph.protocol = l4proto;
-  iph.tot_len = iph6->ip6_hdr.ip6_un1_plen;
+  iph.tot_len = htons(sizeof(struct ndpi_ipv6hdr) + ntohs(iph6->ip6_hdr.ip6_un1_plen));
   return(packet_get_ip_info(6, vlan_id, tunnel_id, &iph, iph6, ipsize, ip_len, l4ptr - (const uint8_t *)iph6,
 	     tcph, udph, sport, dport, proto, payload, payload_len, nf_pkt, n_roots, root_idx, mode));
 }


### PR DESCRIPTION
This fix makes IPv6 `ip_size` calculation consistent with IPv4 for unified accounting modes. IPv6 `ip6_un1_plen` field excludes the IPv6 header (per RFC), while IPv4 `tot_len` includes the IPv4 header. This caused inconsistent accounting behavior between IPv4 and IPv6 flows.

Updated `packet_get_ipv6_info()` to include IPv6 header size in total length calculation for consistent accounting semantics:
- Before: `iph.tot_len = iph6->ip6_hdr.ip6_un1_plen` (payload only)
- After: `iph.tot_len = htons(sizeof(struct ndpi_ipv6hdr) + ntohs(iph6->ip6_hdr.ip6_un1_plen))`

This ensures unified accounting behavior across IPv4 and IPv6:
- Mode 0: Raw packet (all headers + data)
- Mode 1: IP packet (IP header + transport + data)
- Mode 2: Transport segment (transport header + data)
- Mode 3: Application payload (data only)

Previously IPv6 Mode 1 and Mode 2 were identical, now they differ by 40 bytes.