### PR TITLE
Fix PyPy segfault: cap pandas <3 for PyPy

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,8 @@ dependencies = [
   "psutil>=5.8.0",
   "dpkt>=1.9.7",
   "numpy>=1.19.5",
-  "pandas>=1.1.5",
+  "pandas>=1.1.5; implementation_name != 'pypy'",
+  "pandas>=1.1.5,<3; implementation_name == 'pypy'",
 ]
 
 classifiers = [


### PR DESCRIPTION
## Summary

- PyPy-3.11 CI has been failing with a segfault since pandas 3.0.0 was released (Jan 21, 2026)
- `import pandas` itself segfaults under PyPy when pandas 3.0 is installed
- pandas 2.3.3 (which CI was using in Nov 2025) works fine under PyPy
- Since `pandas>=1.1.5` had no upper bound, pip automatically installed 3.0.0 once available

### Fix
Use environment markers in `pyproject.toml` to cap pandas `<3` for PyPy while leaving CPython unconstrained:
```
"pandas>=1.1.5; implementation_name != 'pypy'",
"pandas>=1.1.5,<3; implementation_name == 'pypy'",
```