### PR TITLE
Fix Windows build: install libpcap-dev for nDPI 5.0 configure

### DIFF
--- a/nfstream/engine/scripts/build_windows.sh
+++ b/nfstream/engine/scripts/build_windows.sh
@@ -27,6 +27,8 @@ build_libndpi() {
   echo "---------------------------------------------------------------------------------------------------------------"
   echo "Compiling libndpi"
   echo "---------------------------------------------------------------------------------------------------------------"
+  # nDPI 5.0 configure requires libpcap-dev when using --with-only-libndpi on MinGW
+  pacman -S --noconfirm mingw-w64-x86_64-libpcap
   cd nDPI
   ./autogen.sh
   # nDPI 5.0: Build only the library, not example applications (--with-only-libndpi)


### PR DESCRIPTION
## Summary

- nDPI 5.0 `configure` requires `libpcap` when `--with-only-libndpi` is used on MinGW ([`configure.ac` line 344-346](https://github.com/ntop/nDPI/blob/375f99ef9fb4999d778b57bbeece171b3fa9fba6/configure.ac#L344))
- Install `mingw-w64-x86_64-libpcap` via pacman in `build_windows.sh` befroe running configure

## Context

After merging #230, Windows CI still fails becuase `./configure --with-only-libndpi` triggers a `PKG_CHECK_MODULES` check for `libpcap` on MinGW:

```
checking for libpcap... no
configure: error: Package requirements (libpcap) were not met:
Package 'libpcap' not found
```

Configure fails, so `make` never runs and nDPI headers are never installed, leading to the `IndexError` in `engine_build.py`.