### PR TITLE
Call NFPlugin.cleanup() at the end of the meter workflow

### DIFF
--- a/nfstream/meter.py
+++ b/nfstream/meter.py
@@ -533,6 +533,10 @@ def meter_workflow(
     meter_cleanup(
         cache, channel, udps, sync, n_dissections, statistics, splt, ffi, lib, dissector
     )
+    # All on_expire hooks have run; plugins can now release resources and
+    # persist state accumulated across flows.
+    for udp in udps:
+        udp.cleanup()
     # Clean dissector
     lib.dissector_cleanup(dissector)
     # Release engine library

--- a/tests.py
+++ b/tests.py
@@ -16,8 +16,22 @@ If not, see <http://www.gnu.org/licenses/>.
 import pandas as pd
 import json
 import os
-from nfstream import NFStreamer
+import tempfile
+from nfstream import NFPlugin, NFStreamer
 from nfstream.plugins import SPLT, DHCP, FlowSlicer, MDNS
+
+
+class CleanupPlugin(NFPlugin):
+    def __init__(self, marker_path):
+        self.marker_path = marker_path
+        self.expired = 0
+
+    def on_expire(self, flow):
+        self.expired += 1
+
+    def cleanup(self):
+        with open(self.marker_path, "w") as marker:
+            marker.write(str(self.expired))
 
 
 def get_files_list(path):
@@ -33,6 +47,27 @@ def get_files_list(path):
 
 
 class NFStreamTest(object):
+    @staticmethod
+    def test_plugin_cleanup():
+        print(
+            "\n----------------------------------------------------------------------"
+        )
+        with tempfile.TemporaryDirectory() as directory:
+            marker_path = os.path.join(directory, "cleanup")
+            flows = list(
+                NFStreamer(
+                    source=os.path.join("tests", "pcaps", "google_ssl.pcap"),
+                    udps=CleanupPlugin(marker_path),
+                    n_meters=1,
+                )
+            )
+            with open(marker_path) as marker:
+                expired = int(marker.read())
+            assert expired == len(flows)
+        print(
+            "{}\t: {}".format(".test_plugin_cleanup".ljust(60, " "), "OK")
+        )
+
     @staticmethod
     def test_source_parameter():
         print(
@@ -898,6 +933,7 @@ if __name__ == "__main__":
     NFStreamTest.test_active_timeout_parameter()
     NFStreamTest.test_accounting_mode_parameter()
     NFStreamTest.test_udps_parameter()
+    NFStreamTest.test_plugin_cleanup()
     NFStreamTest.test_n_dissections_parameter()
     NFStreamTest.test_system_visibility_mode_parameter()
     NFStreamTest.test_system_visibility_poll_ms()


### PR DESCRIPTION
## Problem

`NFPlugin.cleanup()` is documented ("Method called for plugin cleanup") but is never actually invoked anywhere in the package. Plugins that buffer state across flows — time-window/bin aggregators, file writers, batched exporters — have no hook to flush their final buffered state, so that data is silently lost at the end of a capture.

## Fix

Invoke `udp.cleanup()` for each plugin in `meter_workflow`, right after `meter_cleanup()` has expired the remaining cached flows (so every `on_expire` hook has already run) and before the meter signals completion via `channel.put(None)`.

## Test

Adds `test_plugin_cleanup`: a plugin counts its `on_expire` calls and writes the total from `cleanup()`. The test asserts the marker file exists (i.e. `cleanup()` was actually called) and that the count equals the number of flows (i.e. it ran after all flows expired).

## Scope note — live captures (follow-up needed)

This fix covers the graceful end-of-capture path, which today is only reached when `capture_next` hits end-of-file — i.e. **file sources**. On **live interfaces** the meter loop has no EOF: stopping via `Ctrl-C` (or reaching `max_nflows`, which internally raises `KeyboardInterrupt`) makes the streamer call `meters[i].terminate()` — a hard kill. In that path neither `meter_cleanup()` (so no `on_expire` for still-cached flows — a pre-existing loss unrelated to this PR) nor the new `cleanup()` hook runs.

A proper live-source fix is a larger coordination change (meters ignoring `SIGINT`, a shared stop event checked in the capture loop, and the streamer draining the channel until each meter sends its `None` sentinel instead of terminating). Deliberately kept out of this PR to keep it a minimal, reviewable fix; noted here so it isn't forgotten — follow-up PR planned.
