### PR TITLE
Remove unused codecov dev dependency

### DIFF
--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -6,5 +6,4 @@ dpkt>=1.9.7
 wheel>=0.47.0
 twine>=6.2.0
 setuptools>=77.0.0
-codecov>=2.1.12
 tqdm>=4.70.0


### PR DESCRIPTION
## Description

The `codecov` PyPI package listed in `dev_requirements.txt` is installed by the four workflows that install development requirements (`build_test_linux`, `build_test_macos`, `build_test_windows`, `codeql-analysis`) but is never invoked.

Coverage upload is performed by the `codecov/codecov-action` GitHub Action in the three `build_test_*` workflows, and `codecov.yml` at the repository root configures the Codecov service consumed by that action. Neither uses the PyPI package. The uploader has also been deprecated upstream in favour of the action and the Codecov CLI.

Coverage reporting is unaffected. It is generated and uploaded from the Linux Python 3.10 job, the macOS Python 3.9 job and the Windows Python 3.9 job (the latter two also gated on non-tag refs), none of which touch this package.

This also makes dependabot PR #239, which bumps the unused package, unnecessary.

Codecov's [deprecated uploader migration guide](https://docs.codecov.com/docs/deprecated-uploader-migration-guide) additionally recommends upgrading `codecov/codecov-action` from v1. That is left as a separate change and is not required for this removal.

## Type of change

- [x] Housekeeping (no functional change)

## How Has This Been Tested?

No functional change. Verified that no workflow, script, or source file invokes the `codecov` command, and that coverage upload is handled entirely by `codecov/codecov-action`.
