### PR TITLE
Do not anonymize absent values

### DIFF
--- a/nfstream/anonymizer.py
+++ b/nfstream/anonymizer.py
@@ -50,9 +50,18 @@ class NFAnonymizer(object):
                         )
             values = flow.values()
             for col_idx in self._cols_index:
-                if values[col_idx] is not None:
+                value = values[col_idx]
+                # Absent values must stay absent. Hashing "" yields a digest that is
+                # constant for the whole export and indistinguishable from a real one,
+                # so consumers would see a large cohort apparently sharing a value.
+                # Only str is compared against "": this is deliberately neither a
+                # truthiness test, since 0 and False are legitimate values that must
+                # still be anonymized, nor an unguarded equality, since a plugin may
+                # store a numpy array whose comparison would not yield a bool.
+                is_absent = value is None or (isinstance(value, str) and value == "")
+                if not is_absent:
                     values[col_idx] = blake2b(
-                        str(values[col_idx]).encode(), digest_size=64, key=self._secret
+                        str(value).encode(), digest_size=64, key=self._secret
                     ).hexdigest()
             return values
         return flow.values()

--- a/tests.py
+++ b/tests.py
@@ -14,9 +14,10 @@ If not, see <http://www.gnu.org/licenses/>.
 """
 
 import pandas as pd
+import numpy as np
 import json
 import os
-from nfstream import NFStreamer
+from nfstream import NFPlugin, NFStreamer
 from nfstream.plugins import SPLT, DHCP, FlowSlicer, MDNS
 
 
@@ -912,6 +913,60 @@ class NFStreamTest(object):
         )
 
     @staticmethod
+    def test_anonymize_absent_values():
+        print(
+            "\n----------------------------------------------------------------------"
+        )
+
+        class MixedValues(NFPlugin):
+            """Produces an absent value alongside values that only look absent."""
+
+            def on_init(self, packet, flow):
+                flow.udps.absent = ""
+                flow.udps.populated = "value"
+                flow.udps.zero = 0
+                flow.udps.false = False
+                flow.udps.array = np.zeros(3)
+
+        df = NFStreamer(
+            source=os.path.join("tests", "pcaps", "google_ssl.pcap"),
+            n_meters=1,
+            udps=MixedValues(),
+        ).to_pandas(
+            columns_to_anonymize=[
+                "udps.absent",
+                "udps.populated",
+                "udps.zero",
+                "udps.false",
+                "udps.array",
+            ]
+        )
+        assert df.shape[0] > 0
+        for _, row in df.iterrows():
+            # An absent value must not be replaced by the digest of "", which would be
+            # constant across the export and indistinguishable from a real value.
+            assert pd.isna(row["udps.absent"])
+            # A populated value is anonymized.
+            assert isinstance(row["udps.populated"], str)
+            assert len(row["udps.populated"]) == 128
+            assert row["udps.populated"] != "value"
+            # 0 and False are legitimate values, not absent ones, so they are still
+            # anonymized: the guard must not degrade into a truthiness test.
+            assert isinstance(row["udps.zero"], str)
+            assert len(row["udps.zero"]) == 128
+            assert isinstance(row["udps.false"], str)
+            assert len(row["udps.false"]) == 128
+            # A plugin may store a numpy array, whose comparison does not yield a
+            # bool; the guard must not raise on it.
+            assert isinstance(row["udps.array"], str)
+            assert len(row["udps.array"]) == 128
+        print(
+            "{}\t: {}".format(
+                ".test_anonymize_absent_values".ljust(60, " "), "OK"
+            )
+        )
+
+    @staticmethod
     def test_max_nflows():
         print(
             "\n----------------------------------------------------------------------"
@@ -967,4 +1022,5 @@ if __name__ == "__main__":
     NFStreamTest.test_mdns()
     NFStreamTest.test_multi_files()
     NFStreamTest.test_optional_string_fields()
+    NFStreamTest.test_anonymize_absent_values()
     NFStreamTest.test_max_nflows()


### PR DESCRIPTION
## Description

`NFAnonymizer.process` guarded only on `None`, so an empty string was hashed like real data. An optional field that was never populated became a 128 character blake2b digest, and because the key is fixed for the duration of one export, **every such flow received the same digest**. A consumer then sees a large cohort apparently sharing one fingerprint, user agent or server name that does not exist, and cannot distinguish it from a genuinely shared value.

Reproduced on `google_ssl.pcap` with `columns_to_anonymize=("client_fingerprint",)`: a flow with no fingerprint exported as `edf5504281e9bd6d…`, 128 hex characters.

This affects `to_csv` as well as `to_pandas`, so anonymized datasets already published may contain these artefacts. The exposure is not marginal: across 218 flows from six bundled pcaps, the optional DPI strings were empty between 27% and 88% of the time.

Absent values are now left untouched.

## The guard

```python
is_absent = value is None or (isinstance(value, str) and value == "")
```

Deliberately **not** a truthiness test, and deliberately **not** an unguarded equality:

- `0` and `False` are legitimate values that must still be anonymized. `src_port` is `0` for every ICMP flow, so skipping falsy values would leak which flows are ICMP.
- Only `str` is compared against `""`, because a plugin may store a NumPy array in a `udps` column, and `value != ""` on an array returns an element-wise array rather than a bool, raising `ValueError` in a boolean context. The previous `is not None` guard did not have that problem, so restricting the comparison to `str` keeps arrays working.

## Type of change

- [x] Bug fix

Note the observable change: a column selected in `columns_to_anonymize` whose value is absent now exports as an empty field instead of a constant digest. That is the bug being fixed, but it does change anonymized output.

## How has this been tested?

Full suite passes locally (macOS, CPython 3.14), including the 227-PCAP nDPI regression corpus and the existing `src_ip`/`dst_ip` anonymization test.

Adds `test_anonymize_absent_values`, which uses a plugin emitting five shapes — `""`, a populated string, `0`, `False` and `np.zeros(3)` — anonymizes all five, and asserts the absent one stays missing while the other four become 128 character digests. The `0`, `False` and array cases exist to prevent the guard from being simplified back into a truthiness test or an unguarded comparison.
