### PR TITLE
Cache pip's wheel cache instead of the interpreter directory

### DIFF
--- a/.github/workflows/build_test_linux.yml
+++ b/.github/workflows/build_test_linux.yml
@@ -33,23 +33,15 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
-        # Caching improves build time, we use pythonLocation to cache everything including wheels to avoid building
-        # wheels at each build (pandas/Pypy is extremely time consuming)
-        # sed replacement is performed to rectify PyPy path which ends with /bin
-        # cache key takes into account the Python version of the runner to avoid version mismatch on updates.
-      - name: Get pip cache path
-        id: get-pip-path
-        run: |
-          id=$(echo ${{ env.pythonLocation }} | sed 's/\/bin//g')
-          echo "::set-output name=id::$id"
-
-      - name: Pip cache
-        uses: actions/cache@v3
-        id: pip-cache
-        with:
-          path: ${{ steps.get-pip-path.outputs.id }}
-          key: ${{ steps.get-pip-path.outputs.id }}-${{ hashFiles('setup.py') }}-${{ hashFiles('dev_requirements.txt') }}
-
+          # Cache pip's own download and wheel cache, not the interpreter directory.
+          # pip reuses wheels it built from source distributions, so the expensive
+          # builds (pandas on PyPy) are still avoided.
+          cache: pip
+          cache-dependency-path: |
+            dev_requirements.txt
+            requirements.txt
+            pyproject.toml
+            setup.py
       - name: Install prerequisites
         run: |
           sudo apt-get update
@@ -57,9 +49,7 @@ jobs:
           sudo apt-get install libusb-1.0-0-dev libdbus-glib-1-dev libbluetooth-dev libnl-genl-3-dev flex bison
 
       - name: Install requirements
-        if: steps.pip-cache.outputs.cache-hit != 'true'
         run: |
-          python -m pip install --upgrade pip
           python -m pip install -r dev_requirements.txt
 
       - name: Build

--- a/.github/workflows/build_test_macos.yml
+++ b/.github/workflows/build_test_macos.yml
@@ -33,31 +33,21 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
-        # Caching improves build time, we use pythonLocation to cache everything including wheels to avoid building
-        # wheels at each build (pandas/Pypy is extremely time consuming)
-        # sed replacement is performed to rectify PyPy path which ends with /bin
-        # cache key takes into account the Python version of the runner to avoid version mismatch on updates.
-      - name: Get pip cache path
-        id: get-pip-path
-        run: |
-          id=$(echo ${{ env.pythonLocation }} | sed 's/\/bin//g')
-          echo "::set-output name=id::$id"
-
-      - name: Pip cache
-        uses: actions/cache@v3
-        id: pip-cache
-        with:
-          path: ${{ steps.get-pip-path.outputs.id }}
-          key: ${{ steps.get-pip-path.outputs.id }}-${{ hashFiles('setup.py') }}-${{ hashFiles('dev_requirements.txt') }}
-
+          # Cache pip's own download and wheel cache, not the interpreter directory.
+          # pip reuses wheels it built from source distributions, so the expensive
+          # builds (pandas on PyPy) are still avoided.
+          cache: pip
+          cache-dependency-path: |
+            dev_requirements.txt
+            requirements.txt
+            pyproject.toml
+            setup.py
       - name: Installing prerequisites
         run: |
           brew install autoconf automake libtool pkg-config gettext json-c gcc
 
       - name: Install requirements
-        if: steps.pip-cache.outputs.cache-hit != 'true'
         run: |
-          python -m pip install --upgrade pip
           python -m pip install -r dev_requirements.txt
 
       - name: Build

--- a/.github/workflows/build_test_windows.yml
+++ b/.github/workflows/build_test_windows.yml
@@ -32,6 +32,15 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
+          # Cache pip's own download and wheel cache, not the interpreter directory.
+          # pip reuses wheels it built from source distributions, so the expensive
+          # builds (pandas on PyPy) are still avoided.
+          cache: pip
+          cache-dependency-path: |
+            dev_requirements.txt
+            requirements.txt
+            pyproject.toml
+            setup.py
 
       - name: Setup msys2
         uses: msys2/setup-msys2@v2
@@ -42,7 +51,6 @@ jobs:
 
       - name: Install requirements
         run: |
-          python -m pip install --upgrade pip
           python -m pip install -r dev_requirements.txt
 
       - name: Install NPCAP OEM


### PR DESCRIPTION
## Description

The `Pip cache` step captured `pythonLocation` — the interpreter installation itself. Every run has `setup-python` freshly provision the interpreter and install its own pip, and `actions/cache` then restored the saved tree **over** that fresh install.

That is consistent with what broke macOS PyPy. Reading the run that created the cache:

```
Successfully installed pip-24.0 setuptools-79.0.1      <- setup-python's own pip
Using cached pip-26.1.2-py3-none-any.whl (1.8 MB)
Uninstalling pip-24.0:                                  <- the workflow's upgrade
```

`Install requirements`, `Build` and `Test` then all succeeded. Later runs skipped `Install requirements` on the cache hit and failed in `Build` with:

```
ImportError: cannot import name 'get_runnable_pip' from 'pip._internal.utils.misc'
```

raised inside pip, before NFStream was reached — a newer `build_env/installer.py` importing a symbol absent from an older `utils/misc.py`. It broke unrelated pull requests for four days and was cleared only by deleting the cache entry by hand.

What is proven is that **pip worked when the cache was saved and was internally inconsistent after it was restored**. Restoring a tree containing pip 26.1.2 over a freshly provisioned pip 24.0 is consistent with that failure and with the specific symbols involved, though the exact file-level interleaving was not reconstructed.

Two further things made it hard to place. It appears only *after* a dependency change rotates the cache key, so it looks like that merge's fault. And it hit macOS/arm64 while Linux used the same cache design and dependency hashes but a different path-derived key and stayed green, so it looked random.

## Change

`setup-python` now owns the caching, storing pip's own download and wheel cache rather than an installation:

```yaml
cache: pip
cache-dependency-path: |
  dev_requirements.txt
  requirements.txt
  pyproject.toml
  setup.py
```

That data is inert, so nothing is ever overlaid onto the interpreter. The bespoke `Get pip cache path` and `Pip cache` steps are removed.

The original comment justified caching `pythonLocation` to avoid rebuilding wheels, since pandas on PyPy is slow. That still holds: pip reuses wheels it built from source distributions, so the expensive builds are avoided and only the install step is repeated.

Requirements are now installed on **every** run rather than skipped on a cache hit, so the environment always matches `dev_requirements.txt`. The explicit `pip install --upgrade pip` is dropped as unnecessary — the version each runner provides is sufficient — which also removes the version skew between the cached and the provisioned interpreter.

## Type of change

- [x] CI change (no library change)

## Note on validation

An earlier revision of this PR only removed the pip upgrade. That was a narrower mitigation resting on a mistaken root cause: the upgrade completed successfully, as the log above shows, so the corruption came from the restore rather than from the upgrade. Removing the upgrade would have held only while `setup-python`'s bundled pip happened to match what had been cached.

Because this change alters how caching works, the first run on each branch will miss and repopulate. The old interpreter-cache entries will no longer be referenced. They may be deleted for storage hygiene, but no manual flush is required.
