### PR TITLE
Define the anonymizer test plugin at module level

### DIFF
--- a/tests.py
+++ b/tests.py
@@ -21,6 +21,17 @@ from nfstream import NFPlugin, NFStreamer
 from nfstream.plugins import SPLT, DHCP, FlowSlicer, MDNS
 
 
+class AnonymizerMixedValues(NFPlugin):
+    """Must remain module-level because Windows spawn pickles plugins."""
+
+    def on_init(self, packet, flow):
+        flow.udps.absent = ""
+        flow.udps.populated = "value"
+        flow.udps.zero = 0
+        flow.udps.false = False
+        flow.udps.array = np.zeros(3)
+
+
 def get_files_list(path):
     files = []
     for r, d, f in os.walk(path):
@@ -918,20 +929,10 @@ class NFStreamTest(object):
             "\n----------------------------------------------------------------------"
         )
 
-        class MixedValues(NFPlugin):
-            """Produces an absent value alongside values that only look absent."""
-
-            def on_init(self, packet, flow):
-                flow.udps.absent = ""
-                flow.udps.populated = "value"
-                flow.udps.zero = 0
-                flow.udps.false = False
-                flow.udps.array = np.zeros(3)
-
         df = NFStreamer(
             source=os.path.join("tests", "pcaps", "google_ssl.pcap"),
             n_meters=1,
-            udps=MixedValues(),
+            udps=AnonymizerMixedValues(),
         ).to_pandas(
             columns_to_anonymize=[
                 "udps.absent",


### PR DESCRIPTION
## Description

`master` currently fails the Windows test suite. `test_anonymize_absent_values`, added in #253, defined its plugin inside the test function:

```
AttributeError: Can't pickle local object
'NFStreamTest.test_anonymize_absent_values.<locals>.MixedValues'
```

Windows spawns meter processes rather than forking them, so plugin instances must be pickled to reach them, and a class defined in a function body cannot be pickled. Linux and macOS fork, so the plugin was inherited rather than pickled and the test passed there — including in the local runs used to validate #253.

The failure was also masked initially: the Windows jobs were failing earlier, at the Npcap download, and never reached the tests at all.

Moving the class to module level makes it picklable, matching how the other plugins used in the suite are defined.

## Type of change

- [x] Bug fix (test only, no library change)

## How has this been tested?

`pickle.dumps()` on the relocated class succeeds where the function-local version raises. Windows CI on this pull request is the real check, since the failure only appears under the spawn start method.
