### PR TITLE
Cancel superseded workflow runs

### DIFF
--- a/.github/workflows/build_test_linux.yml
+++ b/.github/workflows/build_test_linux.yml
@@ -6,6 +6,12 @@ on:
   pull_request:
     branches:
       - master
+# A newer commit on the same ref supersedes this run, so cancel the older one
+# instead of letting both compete for runners.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build_test_linux:
     name: ${{ matrix.python-version }} on ${{ matrix.os }}

--- a/.github/workflows/build_test_macos.yml
+++ b/.github/workflows/build_test_macos.yml
@@ -6,6 +6,12 @@ on:
   pull_request:
     branches:
       - master
+# A newer commit on the same ref supersedes this run, so cancel the older one
+# instead of letting both compete for runners.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build_test_macos:
     name: ${{ matrix.python-version }} on ${{ matrix.os }}

--- a/.github/workflows/build_test_windows.yml
+++ b/.github/workflows/build_test_windows.yml
@@ -6,6 +6,12 @@ on:
   pull_request:
     branches:
       - master
+# A newer commit on the same ref supersedes this run, so cancel the older one
+# instead of letting both compete for runners.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build_test_windows:
     name: ${{ matrix.python-version }} on ${{ matrix.os }}


### PR DESCRIPTION
## Description

Consecutive merges each start a full matrix on `master`, and without a concurrency group the older runs keep competing for runners even though the newer commit already contains their changes. When multiple merges land within minutes, the superseded runs have to be cancelled by hand — and manual cancellation risks cancelling the newest run instead.

Grouping by workflow and ref lets GitHub cancel the superseded run automatically:

```yaml
concurrency:
  group: ${{ github.workflow }}-${{ github.ref }}
  cancel-in-progress: true
```

Applied to the three `build_test_*` workflows only. `build_wheel_publish` is deliberately excluded because release and publication jobs are not supersedable and must run to completion. `cifuzz` and `codeql` remain unchanged; this PR is intentionally scoped to the three OS build matrices where the duplication occurs.

## Type of change

- [x] CI change (no library change)

## Effect on pull requests

Pushing a new commit to an open pull request now cancels the in-flight `build_test_*` runs for its previous commit. Those runs remain recorded as cancelled rather than producing completed matrix results. This is intentional because the newer commit supersedes them. Runs belonging to other pull requests use different refs and remain independent.
