### PR TITLE
Make the Npcap downloads resilient and their failures legible

### DIFF
--- a/.github/workflows/build_test_windows.yml
+++ b/.github/workflows/build_test_windows.yml
@@ -60,11 +60,39 @@ jobs:
           python -m pip install -r dev_requirements.txt
 
       - name: Install NPCAP OEM
+        env:
+          NPCAP_OEM_USERNAME: ${{ secrets.NPCAP_OEM_USERNAME }}
+          NPCAP_OEM_PASSWORD: ${{ secrets.NPCAP_OEM_PASSWORD }}
         run: |
           choco install wget --no-progress
-          wget --user ${{ secrets.NPCAP_OEM_USERNAME }} --password ${{ secrets.NPCAP_OEM_PASSWORD }} https://npcap.org/oem/dist/npcap-1.60-oem.exe
-          Start-Process npcap-1.60-oem.exe -ArgumentList "/loopback_support=yes /winpcap_mode=yes /dot11_support=yes /S" -wait
-
+          # npcap.com is periodically unreachable or refuses the TLS handshake. Retry, and
+          # fail with an explicit message rather than letting Start-Process report a missing
+          # file. -O keeps a failed attempt from being left behind under a .1 suffix.
+          $installer = "npcap-1.60-oem.exe"
+          $downloaded = $false
+          for ($attempt = 1; $attempt -le 5; $attempt++) {
+            Remove-Item -Force -ErrorAction SilentlyContinue $installer
+            wget --tries=3 --timeout=30 `
+              "--user=$env:NPCAP_OEM_USERNAME" `
+              "--password=$env:NPCAP_OEM_PASSWORD" `
+              -O $installer https://npcap.com/oem/dist/npcap-1.60-oem.exe
+            if ($LASTEXITCODE -eq 0) { $downloaded = $true; break }
+            if ($attempt -lt 5) {
+              Write-Host "Npcap OEM download attempt $attempt failed; retrying in 15 seconds"
+              Start-Sleep -Seconds 15
+            }
+          }
+          if (-not $downloaded) {
+            Write-Error "ERROR: unable to download the Npcap OEM installer"
+            exit 1
+          }
+          $process = Start-Process $installer `
+            -ArgumentList "/loopback_support=yes /winpcap_mode=yes /dot11_support=yes /S" `
+            -Wait -PassThru
+          if ($process.ExitCode -ne 0) {
+            Write-Error "ERROR: Npcap installation failed with exit code $($process.ExitCode)"
+            exit 1
+          }
       - name: Build
         env:
           MSYSTEM: MINGW64

--- a/.github/workflows/build_wheel_publish.yml
+++ b/.github/workflows/build_wheel_publish.yml
@@ -67,11 +67,39 @@ jobs:
 
       - name: Install NPCAP OEM on Windows
         shell: pwsh
+        env:
+          NPCAP_OEM_USERNAME: ${{ secrets.NPCAP_OEM_USERNAME }}
+          NPCAP_OEM_PASSWORD: ${{ secrets.NPCAP_OEM_PASSWORD }}
         run: |
           choco install wget --no-progress
-          wget --user ${{ secrets.NPCAP_OEM_USERNAME }} --password ${{ secrets.NPCAP_OEM_PASSWORD }} https://npcap.org/oem/dist/npcap-1.60-oem.exe
-          Start-Process npcap-1.60-oem.exe -ArgumentList "/loopback_support=yes /winpcap_mode=yes /dot11_support=yes /S" -Wait
-
+          # npcap.com is periodically unreachable or refuses the TLS handshake. Retry, and
+          # fail with an explicit message rather than letting Start-Process report a missing
+          # file. -O keeps a failed attempt from being left behind under a .1 suffix.
+          $installer = "npcap-1.60-oem.exe"
+          $downloaded = $false
+          for ($attempt = 1; $attempt -le 5; $attempt++) {
+            Remove-Item -Force -ErrorAction SilentlyContinue $installer
+            wget --tries=3 --timeout=30 `
+              "--user=$env:NPCAP_OEM_USERNAME" `
+              "--password=$env:NPCAP_OEM_PASSWORD" `
+              -O $installer https://npcap.com/oem/dist/npcap-1.60-oem.exe
+            if ($LASTEXITCODE -eq 0) { $downloaded = $true; break }
+            if ($attempt -lt 5) {
+              Write-Host "Npcap OEM download attempt $attempt failed; retrying in 15 seconds"
+              Start-Sleep -Seconds 15
+            }
+          }
+          if (-not $downloaded) {
+            Write-Error "ERROR: unable to download the Npcap OEM installer"
+            exit 1
+          }
+          $process = Start-Process $installer `
+            -ArgumentList "/loopback_support=yes /winpcap_mode=yes /dot11_support=yes /S" `
+            -Wait -PassThru
+          if ($process.ExitCode -ne 0) {
+            Write-Error "ERROR: Npcap installation failed with exit code $($process.ExitCode)"
+            exit 1
+          }
       - name: Build wheels (Windows)
         uses: pypa/cibuildwheel@v3.3.0
         env:

--- a/nfstream/engine/scripts/build_windows.sh
+++ b/nfstream/engine/scripts/build_windows.sh
@@ -16,8 +16,46 @@ setup_npcap() {
   echo "---------------------------------------------------------------------------------------------------------------"
   echo "Setup npcap SDK"
   echo "---------------------------------------------------------------------------------------------------------------"
-  wget https://npcap.com/dist/npcap-sdk-1.12.zip -P /tmp/nfstream_build/
-  unzip /tmp/nfstream_build/npcap-sdk-1.12.zip -d /tmp/nfstream_build/npcap/
+  sdk=/tmp/nfstream_build/npcap-sdk-1.12.zip
+  mkdir -p /tmp/nfstream_build
+
+  # npcap.com is periodically unreachable or refuses the TLS handshake. Retry, write to a
+  # fixed path so a partial download cannot be left behind under a .1 suffix, and fail
+  # loudly here rather than hundreds of lines later in the compiler.
+  downloaded=false
+  for attempt in 1 2 3 4 5; do
+    rm -f "$sdk"
+
+    if wget --tries=3 --timeout=30 -O "$sdk" https://npcap.com/dist/npcap-sdk-1.12.zip; then
+      downloaded=true
+      break
+    fi
+
+    if [ "$attempt" -lt 5 ]; then
+      echo "Npcap SDK download attempt $attempt failed; retrying in 15 seconds"
+      sleep 15
+    fi
+  done
+
+  [ "$downloaded" = true ] || {
+    echo "ERROR: unable to download the Npcap SDK" >&2
+    return 1
+  }
+
+  unzip -o "$sdk" -d /tmp/nfstream_build/npcap/ || {
+    echo "ERROR: unable to extract the Npcap SDK" >&2
+    return 1
+  }
+
+  [ -f /tmp/nfstream_build/npcap/Include/pcap.h ] || {
+    echo "ERROR: Npcap SDK is missing Include/pcap.h" >&2
+    return 1
+  }
+
+  [ -f /tmp/nfstream_build/npcap/Lib/x64/wpcap.lib ] || {
+    echo "ERROR: Npcap SDK is missing Lib/x64/wpcap.lib" >&2
+    return 1
+  }
   echo "---------------------------------------------------------------------------------------------------------------"
   echo ""
   }
@@ -42,7 +80,7 @@ build_libndpi() {
 
 rm -rf /tmp/nfstream_build
 cd $1/dependencies
-setup_npcap
+setup_npcap || exit 1
 build_libndpi
 echo ""
 echo "---------------------------------------------------------------------------------------------------------------"


### PR DESCRIPTION
## Description

The Windows build fetches two artifacts from npcap.com — the OEM installer in the workflows, and the SDK zip in `build_windows.sh` — and that host periodically refuses the TLS handshake:

```
Connecting to npcap.com|50.116.1.184|:443... connected.
Unable to establish SSL connection.
```

A single failed attempt failed the job. Because each matrix job downloads independently, whichever jobs were unlucky failed while their siblings passed, and fail-fast cancelled the rest — so the failing Python version differed run to run and looked like a property of the change under test rather than of the network.

### The SDK fetch checked nothing

`wget` wrote into a directory with `-P`, so a partial download could be left in place and a later attempt would create a `.1` file while `unzip` kept reading the corrupt original. Neither the `wget` nor the `unzip` result was inspected, and the script sets no `set -e`, so a failed fetch continued and resurfaced hundreds of lines later as `fatal error C1083: Cannot open include file: 'pcap.h'`.

It now retries, writes to a fixed path, fails explicitly once the attempts are exhausted, and validates both files the build actually consumes — `Include/pcap.h` and `Lib/x64/wpcap.lib`, the latter linked by `engine_build.py`. The call site is `setup_npcap || exit 1`, and `subprocess.check_call` surfaces the failure.

### The OEM installer

Same retry treatment in both `build_test_windows.yml` and `build_wheel_publish.yml`, checking the `wget` exit status rather than the file's existence, since `-O` creates the target even on failure.

Its **installation** result is now checked too. `Start-Process -Wait` does not fail when the child exits nonzero, so a failed installation was previously indistinguishable from a successful one — the same silent-failure shape as the SDK fetch, one step further along.

Two smaller changes: the requests address `npcap.com` directly rather than relying on the `npcap.org` redirect, and the credentials are passed through `env:` rather than interpolated into the script, so characters significant to PowerShell cannot alter it.

## Type of change

- [x] Build and CI robustness (no library change)

## Scope

Retries make transient failures survivable and sustained outages legible. They do not help pull requests from forks, where the credentials are unavailable and the download cannot succeed at all — those now spend the retry budget before reporting a clear error.

Caching was considered and deliberately left out of this PR. Although the public SDK could be cached, fork pull requests can restore base-branch caches, so caching the credential-gated OEM installer in a public repository would expose it to arbitrary fork code.

## How has this been tested?

`bash -n` was run on the build script and both workflows were YAML-parsed. The pull request's Windows matrix exercises the SDK download and the OEM installer logic in `build_test_windows.yml`. The equivalent block in `build_wheel_publish.yml` is not triggered by pull requests and therefore receives syntax validation only.
