### PR TITLE
Ignore incompatible Twine major updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,7 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "daily"
+    ignore:
+      # Twine 7 drops Python 3.9; remove when NFStream drops Python 3.9.
+      - dependency-name: "twine"
+        update-types: ["version-update:semver-major"]


### PR DESCRIPTION
## Description

Twine 7 requires Python `>=3.10`, while NFStream still supports Python 3.9
(`requires-python = ">=3.9"`, with 3.9 in every CI matrix). Raising the floor to
`twine>=7.0.0` would make `dev_requirements.txt` uninstallable on 3.9.

The existing `twine>=6.2.0` constraint already resolves the newest usable version per
interpreter. From the current master run:

| Python | Twine resolved |
| --- | --- |
| 3.9 | 6.2.0 |
| 3.10-3.14 and PyPy 3.11 | 7.0.0 |

So the major bump gains nothing on newer interpreters and breaks the oldest supported one.
Dependabot proposed it as #252, and will keep proposing it — closing such a pull request
suppresses only the specific release, so Twine 7.1 would open an identical one.

This adds an `ignore` entry for Twine major updates instead. It is version-controlled and
self-documenting, and a single comment records when to remove it. Once NFStream drops
Python 3.9, remove this block and reassess the appropriate Twine minimum.

Only updates that cross the current 6.x major-version boundary are ignored. Compatible
updates within the 6.x line remain eligible. Python >=3.10 environments can still install
Twine 7 through the existing open-ended constraint; this rule only prevents Dependabot from
rewriting the declared minimum to an incompatible major version. No other dependency is
affected.

## Type of change

- [x] Dependency automation configuration (no library change)

## How has this been tested?

`.github/dependabot.yml` was parsed to confirm it is valid YAML and that the `ignore` entry
attaches to the `pip` ecosystem rather than sitting at the top level. The file is not
consumed by any workflow, so there is no CI behaviour to exercise; Dependabot validates it on
its next scheduled run, and the effect is visible as the absence of a re-proposed Twine 7
pull request.
